### PR TITLE
Fix standard deviation formula

### DIFF
--- a/irqlist.c
+++ b/irqlist.c
@@ -162,8 +162,13 @@ static void find_overloaded_objs(GList *name, struct load_balance_info *info) {
 	info->load_sources = (info->load_sources == 0) ? 1 : (info->load_sources);
 	info->avg_load = info->total_load / info->load_sources;
 	for_each_object(name, compute_deviations, info);
-	info->std_deviation = (long double)(info->deviations / info->load_sources - 1);
-	info->std_deviation = sqrt(info->std_deviation);
+	/* Don't divide by zero if there is a single load source */
+	if (info->load_sources == 1)
+		info->std_deviation = 0;
+	else {
+		info->std_deviation = (long double)(info->deviations / (info->load_sources - 1));
+		info->std_deviation = sqrt(info->std_deviation);
+	}
 
 	for_each_object(name, migrate_overloaded_irqs, info);
 }


### PR DESCRIPTION
The standard deviation formula is sqrt(deviations / (N-1)) but
not sqrt(deviations/N - 1). I'm not sure but probably standard
deviation must be 0 when N==1. In any case we can't divide by
zero.

Signed-off-by: Serj Kalichev serj.kalichev@gmail.com
