### PR TITLE
Balance correctly IRQs reappearing

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -181,6 +181,14 @@ void parse_proc_interrupts(void)
 			break;
 		}
 
+		/* IRQ removed and reinserted, need restart or this will
+		 * cause an overflow and IRQ won't be rebalanced again
+		 */
+		if (count < info->irq_count) {
+			need_rescan = 1;
+			break;
+		}
+
 		info->last_irq_count = info->irq_count;		
 		info->irq_count = count;
 


### PR DESCRIPTION
If IRQ disappears and reappears later (this happens frequently for Xen)
the IRQ is not balanced correctly due to overflow in irq_count (as the
counter got smaller and difference cause overflow).
Rescan if this happens fix the problem.

Signed-off-by: Frediano Ziglio frediano.ziglio@citrix.com
