### PR TITLE
Initialization bugfix and marking functions static where appropriate

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -57,7 +57,7 @@ char *banscript = NULL;
 char *polscript = NULL;
 long HZ;
 
-void sleep_approx(int seconds)
+static void sleep_approx(int seconds)
 {
 	struct timespec ts;
 	struct timeval tv;
@@ -209,7 +209,7 @@ static void dump_object_tree(void)
 	for_each_object(numa_nodes, dump_numa_node_info, NULL);
 }
 
-void force_rebalance_irq(struct irq_info *info, void *data __attribute__((unused)))
+static void force_rebalance_irq(struct irq_info *info, void *data __attribute__((unused)))
 {
 	if (info->level == BALANCE_NONE)
 		return;

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -110,8 +110,6 @@ extern void add_cl_banned_irq(int irq);
 extern void for_each_irq(GList *list, void (*cb)(struct irq_info *info,  void *data), void *data);
 extern struct irq_info *get_irq_info(int irq);
 extern void migrate_irq(GList **from, GList **to, struct irq_info *info);
-extern struct irq_info *add_new_irq(int irq, struct irq_info *hint);
-extern void force_rebalance_irq(struct irq_info *info, void *data);
 #define irq_numa_node(irq) ((irq)->numa_node)
 
 


### PR DESCRIPTION
This fixes a bug where the user policy was left uninitialized if no policy script was provided.  This also markes some funcitons and globals as static where appropriate and removes the return type of add_new_irq() since nothing was using it.
