### PR TITLE
Fix bitmap_scnprintf giving truncated output when nmaskbits > 32.

### DIFF
--- a/bitmap.c
+++ b/bitmap.c
@@ -291,10 +291,10 @@ int bitmap_scnprintf(char *buf, unsigned int buflen,
 		if (val!=0 || !first || i==0)  {
 			len += snprintf(buf+len, buflen-len, "%s%0*lx", sep,
 				(chunksz+3)/4, val);
-			chunksz = CHUNKSZ;
 			sep = ",";
 			first = 0;
 		}
+		chunksz = CHUNKSZ;
 	}
 	return len;
 }


### PR DESCRIPTION
Test program:

/\* assumes 64-bit arch _/
int main(int argc, char *_argv)
{
    char buf[1024];
    unsigned long mask = 0x0000000002000002UL;
    bitmap_scnprintf(buf, sizeof(buf), &mask, 48);
    printf("%s\n", buf);
    return 0;
}

Without the patch, the test prints "0002".
With the patch, the test prints "02000002".
