### PR TITLE
Fix inconsequential bug in bitmap_scnprintf

### DIFF
--- a/bitmap.c
+++ b/bitmap.c
@@ -291,10 +291,10 @@ int bitmap_scnprintf(char *buf, unsigned int buflen,
 		if (val!=0 || !first || i==0)  {
 			len += snprintf(buf+len, buflen-len, "%s%0*lx", sep,
 				(chunksz+3)/4, val);
-			chunksz = CHUNKSZ;
 			sep = ",";
 			first = 0;
 		}
+		chunksz = CHUNKSZ;
 	}
 	return len;
 }


### PR DESCRIPTION
Fix incorrect code in bitmap_scnprintf that could cause it to give truncated
output when nmaskbits > 32 and nmaskbits % 32 != 0.  In practice this problem
was never encountered because NR_CPUS % 32 == 0.  So this change fixes the
code for the sake of correctness even though the bug did not actually cause a
real problem.
