### PR TITLE
Fix sort_irqs()

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -614,7 +614,15 @@ static gint sort_irqs(gconstpointer A, gconstpointer B)
         a = (struct irq_info*)A;
         b = (struct irq_info*)B;
 
-	if (a->class < b->class || a->load < b->load || a < b)
+	if (a->class < b->class)
+		return 1;
+	if (a->class > b->class)
+		return -1;
+	if (a->load < b->load)
+		return 1;
+	if (a->load > b->load)
+		return -1;
+	if (a < b)
 		return 1;
         return -1;
 }


### PR DESCRIPTION
Sort_irqs() should sort irq_info object by class firstly, then by load,
and finally by address. Current code considers class/load/address at the
same priority. This is not desirable because objects with lower class or
load value (but larger address) will be put before objects with larger
class or load value.

Signed-off-by: Jason Zeng <zrzeng@gmail.com>