### PR TITLE
bug-893478_warn-once

### DIFF
--- a/activate.c
+++ b/activate.c
@@ -84,11 +84,14 @@ static void activate_mapping(struct irq_info *info, void *data __attribute__((un
 		if ((info->hint_policy == HINT_POLICY_SUBSET) &&
 		    (!cpus_empty(info->affinity_hint))) {
 			cpus_and(applied_mask, applied_mask, info->affinity_hint);
-			if (!cpus_intersects(applied_mask, unbanned_cpus))
-				log(TO_ALL, LOG_WARNING,
-				    "irq %d affinity_hint subset empty\n",
-				   info->irq);
-			else
+			if (!cpus_intersects(applied_mask, unbanned_cpus)) {
+				if (!info->warned) {
+					info->warned = 1;
+					log(TO_ALL, LOG_WARNING,
+					    "irq %d affinity_hint subset empty\n",
+					    info->irq);
+				}
+			} else
 				valid_mask = 1;
 		} else {
 			valid_mask = 1;

--- a/types.h
+++ b/types.h
@@ -71,6 +71,7 @@ struct irq_info {
 	uint64_t load;
 	int moved;
 struct topo_obj *assigned_obj;
+   unsigned int warned;
 };
 
 #endif


### PR DESCRIPTION
Only warn once for affinity hint subset empty irqs
https://bugzilla.novell.com/show_bug.cgi?id=893478