### PR TITLE
automatically add isolated cpus to banned_cpus

### DIFF
--- a/bitmap.h
+++ b/bitmap.h
@@ -185,8 +185,8 @@ extern int __bitmap_parse(const char *buf, unsigned int buflen, int is_user,
 			unsigned long *dst, int nbits);
 extern int bitmap_scnlistprintf(char *buf, unsigned int len,
 			const unsigned long *src, int nbits);
-extern int bitmap_parselist(const char *buf, unsigned long *maskp,
-			int nmaskbits);
+extern int __bitmap_parselist(const char *buf, unsigned int buflen, int is_user,
+			unsigned long *dst, int nbits);
 extern void bitmap_remap(unsigned long *dst, const unsigned long *src,
 		const unsigned long *old, const unsigned long *new, int bits);
 extern int bitmap_bitremap(int oldbit,
@@ -349,6 +349,12 @@ static inline int bitmap_parse(const char *buf, unsigned int buflen,
 			unsigned long *maskp, int nmaskbits)
 {
 	return __bitmap_parse(buf, buflen, 0, maskp, nmaskbits);
+}
+
+static inline int bitmap_parselist(const char *buf, unsigned int buflen,
+			unsigned long *maskp, int nmaskbits)
+{
+	return __bitmap_parselist(buf, buflen, 0, maskp, nmaskbits);
 }
 
 #endif /* __ASSEMBLY__ */

--- a/cpumask.h
+++ b/cpumask.h
@@ -281,10 +281,10 @@ static inline int __cpulist_scnprintf(char *buf, int len,
 	return bitmap_scnlistprintf(buf, len, srcp->bits, nbits);
 }
 
-#define cpulist_parse(buf, dst) __cpulist_parse((buf), &(dst), NR_CPUS)
-static inline int __cpulist_parse(const char *buf, cpumask_t *dstp, int nbits)
+#define cpulist_parse(buf, len, dst) __cpulist_parse((buf), (len), &(dst), NR_CPUS)
+static inline int __cpulist_parse(const char *buf, int len, cpumask_t *dstp, int nbits)
 {
-	return bitmap_parselist(buf, dstp->bits, nbits);
+	return bitmap_parselist(buf, len, dstp->bits, nbits);
 }
 
 #define cpu_remap(oldbit, old, new) \

--- a/cputree.c
+++ b/cputree.c
@@ -58,6 +58,48 @@ cpumask_t cpu_possible_map;
 */
 cpumask_t unbanned_cpus;
 
+/*
+ * By default do not place IRQs on CPUs the kernel keeps isolated,
+ * as specified through the isolcpus= boot commandline. Users can
+ * override this with the IRQBALANCE_BANNED_CPUS environment variable.
+ */
+static void setup_banned_cpus(void)
+{
+	FILE *file;
+	char *c, *line = NULL;
+	size_t size = 0;
+	const char *isolcpus = "isolcpus=";
+	char buffer[4096];
+
+	/* A manually specified cpumask overrides auto-detection. */
+	if (getenv("IRQBALANCE_BANNED_CPUS"))  {
+		cpumask_parse_user(getenv("IRQBALANCE_BANNED_CPUS"), strlen(getenv("IRQBALANCE_BANNED_CPUS")), banned_cpus);
+		goto out;
+	}
+
+	file = fopen("/proc/cmdline", "r");
+	if (!file)
+		goto out;
+
+	if (getline(&line, &size, file) <= 0)
+		goto out;
+
+	if ((c = strstr(line, isolcpus))) {
+		char *end;
+		int len;
+
+		c += strlen(isolcpus);
+		for (end = c; *end != ' ' && *end != '\0' && *end != '\n'; end++);
+		len = end - c;
+
+		cpulist_parse(c, len, banned_cpus);
+	}
+
+ out:
+	cpumask_scnprintf(buffer, 4096, banned_cpus);
+	log(TO_CONSOLE, LOG_INFO, "Isolated CPUs: %s\n", buffer);
+}
+
 static struct topo_obj* add_cache_domain_to_package(struct topo_obj *cache, 
 						    int packageid, cpumask_t package_mask)
 {
@@ -371,6 +413,8 @@ void parse_cpu_tree(void)
 {
 	DIR *dir;
 	struct dirent *entry;
+
+	setup_banned_cpus();
 
 	cpus_complement(unbanned_cpus, banned_cpus);
 

--- a/irqbalance.c
+++ b/irqbalance.c
@@ -276,10 +276,6 @@ int main(int argc, char** argv)
  	 */
 	openlog(argv[0], 0, LOG_DAEMON);
 
-	if (getenv("IRQBALANCE_BANNED_CPUS"))  {
-		cpumask_parse_user(getenv("IRQBALANCE_BANNED_CPUS"), strlen(getenv("IRQBALANCE_BANNED_CPUS")), banned_cpus);
-	}
-
 	if (getenv("IRQBALANCE_ONESHOT")) 
 		one_shot_mode=1;
 


### PR DESCRIPTION
These patches add code to parse /proc/cmdline, extract the isolcpus= argument, and automatically add those isolated cpus to the banned_cpus mask.

This ensures that IRQs will not get assigned to CPUs that are supposed to be isolated from system activity.