### PR TITLE
find best place for larger workload ahead

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -867,3 +867,9 @@ void sort_irq_list(GList **list)
 {
 	*list = g_list_sort(*list, sort_irqs);
 }
+
+void sort_irq_list_reverse(GList **list)
+{
+	*list = g_list_sort(*list, sort_irqs);
+	*list = g_list_reverse(*list);
+}

--- a/glib-local/glist.c
+++ b/glib-local/glist.c
@@ -152,6 +152,32 @@ g_list_delete_link (GList *list,
 }
 
 /**
+ * g_list_reverse:
+ * @list: a #GList, this must point to the top of the list
+ *
+ * Reverses a #GList.
+ * It simply switches the next and prev pointers of each element.
+ *
+ * Returns: the start of the reversed #GList
+ */
+GList *
+g_list_reverse (GList *list)
+{
+  GList *last;
+
+  last = NULL;
+  while (list)
+    {
+      last = list;
+      list = last->next;
+      last->next = last->prev;
+      last->prev = list;
+    }
+
+  return last;
+}
+
+/**
  * g_list_first:
  * @list: a #GList
  *

--- a/glib-local/glist.h
+++ b/glib-local/glist.h
@@ -34,6 +34,7 @@ GList*   g_list_delete_link             (GList            *list,
 GList*   g_list_first                   (GList            *list);
 GList*   g_list_sort                    (GList            *list,
 					 GCompareFunc      compare_func);
+GList*   g_list_reverse                 (GList            *list);
 guint    g_list_length                  (GList            *list);
 void     g_list_foreach                 (GList            *list,
 					 GFunc             func,

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -41,6 +41,7 @@ extern GList *rebalance_irq_list;
 void update_migration_status(void);
 void dump_workloads(void);
 void sort_irq_list(GList **list);
+void sort_irq_list_reverse(GList **list);
 void calculate_placement(void);
 void dump_tree(void);
 

--- a/placement.c
+++ b/placement.c
@@ -137,6 +137,7 @@ static void find_best_object_for_irq(struct irq_info *info, void *data)
 static void place_irq_in_object(struct topo_obj *d, void *data __attribute__((unused)))
 {
 	if (g_list_length(d->interrupts) > 0)
+                sort_irq_list_reverse(&d->interrupts);
 		for_each_irq(d->interrupts, find_best_object_for_irq, d);
 }
 
@@ -204,7 +205,7 @@ static void validate_object_tree_placement(void)
 
 void calculate_placement(void)
 {
-	sort_irq_list(&rebalance_irq_list);
+	sort_irq_list_reverse(&rebalance_irq_list);
 	if (g_list_length(rebalance_irq_list) > 0) {
 		for_each_irq(rebalance_irq_list, place_irq_in_node, NULL);
 		for_each_object(numa_nodes, place_irq_in_object, NULL);


### PR DESCRIPTION
This makes a change in migration updating so that finding best place for rebalancing-required irqs with larger workload ahead of less ones. Eventual expected load variance becomes less.