### PR TITLE
Fix sort_irqs() logic

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -855,10 +855,19 @@ void migrate_irq(GList **from, GList **to, struct irq_info *info)
 static gint sort_irqs(gconstpointer A, gconstpointer B)
 {
         struct irq_info *a, *b;
+        
         a = (struct irq_info*)A;
         b = (struct irq_info*)B;
 
-	if (a->class < b->class || a->load < b->load || a < b)
+	if (a->class < b->class)
+		return 1;
+	if (a->class > b->class)
+		return -1;
+	if (a->load < b->load)
+		return 1;
+	if (a->load > b->load)
+		return -1;
+	if (a < b)
 		return 1;
         return -1;
 }


### PR DESCRIPTION
Commit 37c1f simplified sort_irq() logic, but it introduced some unintended
ordering behavior.

I found it by adding two debug messages into migrate_overloaded_irqs() and
move_candidate_irqs() that show the results of sort_irq() as follows:

[Correct case]:
  migrate_overloaded_irqs(): obj_type 0 number 3
   move_candidate_irqs(): Irq  68 class 4 load 3870960 irq_info 0x0x26210d0
   move_candidate_irqs(): Irq  71 class 4 load 3225800 irq_info 0x0x2621e20
   move_candidate_irqs(): Irq  63 class 4 load 2903220 irq_info 0x0x261faa0

[Incorrect case]:
  migrate_overloaded_irqs(): obj_type 0 number 0
   move_candidate_irqs(): Irq  77 class 4 load 4347820 irq_info 0x0x262e050
   move_candidate_irqs(): Irq  69 class 4 load 1 irq_info 0x0x2621540
   move_candidate_irqs(): Irq  61 class 4 load 5652166 irq_info 0x0x261f1c0

The sort order should be primarily "class", secondarily "load", and finally 
the address of struct "irq_info" in descending order each, but apparently it
failed.

This is because sort_irq() should return -1 but does return 1 incorrectly
if (a->class == b->class && a->load > b->load && a < b) with the current
logic.

The solution here is to go back to the original logic.
I confirmed that the incorrect bahavior disappeared with the followin patch.

Signed-off-by: Seiichi Ikarashi <s.ikarashi@jp.fujitsu.com>