### PR TITLE
Prefer pkgconfig to check for ncursesw.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,13 @@ AC_CHECK_FUNCS(getopt_long)
 AC_CHECK_LIB(numa, numa_available)
 AC_CHECK_LIB(m, floor)
 
-AC_CHECK_LIB(curses, mvprintw)
+PKG_CHECK_MODULES([NCURSESW], [ncursesw], [has_ncursesw=yes], [AC_CHECK_LIB(curses, mvprintw)])
+AS_IF([test "x$has_ncursesw" = "xyes"], [
+  AC_SUBST([NCURSESW_CFLAGS])
+  AC_SUBST([NCURSESW_LIBS])
+  LIBS="$LIBS $NCURSESW_LIBS"
+  AC_SUBST([LIBS])
+])
 
 AC_C_CONST
 AC_C_INLINE


### PR DESCRIPTION
That way we take possible separate tinfo lib into account.

Otherwise the following happens when ncurses was built with separate tinfo library:
```
libtool: link: x86_64-pc-linux-gnu-gcc -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -march=native -mtune=native -O2 -pipe -Wl,-O1 -Wl,--hash-style=gnu -Wl,--sort-common -o irqbalance-ui ui/helpers.o ui/irqbalance-ui.o ui/ui.o  -Wl,--as-needed -lglib-2.0 -lcurses -lm -lnuma
/usr/lib/gcc/x86_64-pc-linux-gnu/5.4.0/../../../../x86_64-pc-linux-gnu/bin/ld: ui/ui.o: undefined reference to symbol 'nodelay'
/lib64/libtinfo.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:564: irqbalance-ui] Error 1
```