### PR TITLE
Fix broken build

### DIFF
--- a/ui/helpers.c
+++ b/ui/helpers.c
@@ -75,7 +75,7 @@ char * hex_to_bitmap(char hex_digit) {
 
 	char *bitmap = malloc(5 * sizeof(char));
 	bitmap[4] = '\0';
-    int i = 3;
+	int i = 0;
 	for(i = 3; i >= 0; i--) {
 		bitmap[i] = digit % 2 ? '1' : '0';
 		digit /= 2;

--- a/ui/helpers.c
+++ b/ui/helpers.c
@@ -75,7 +75,8 @@ char * hex_to_bitmap(char hex_digit) {
 
 	char *bitmap = malloc(5 * sizeof(char));
 	bitmap[4] = '\0';
-	for(int i = 3; i >= 0; i--) {
+    int i = 3;
+	for(i = 3; i >= 0; i--) {
 		bitmap[i] = digit % 2 ? '1' : '0';
 		digit /= 2;
 	}
@@ -84,7 +85,7 @@ char * hex_to_bitmap(char hex_digit) {
 
 gpointer copy_cpu_ban(gconstpointer src, gpointer data __attribute__((unused)))
 {
-	cpu_ban_t *old = (cpu_ban_t *)src; 
+	cpu_ban_t *old = (cpu_ban_t *)src;
 	cpu_ban_t *new = malloc(sizeof(cpu_ban_t));
 	new->number = old->number;
 	new->is_banned = old->is_banned;
@@ -93,7 +94,7 @@ gpointer copy_cpu_ban(gconstpointer src, gpointer data __attribute__((unused)))
 
 gpointer copy_irq(gconstpointer src, gpointer data __attribute__((unused)))
 {
-	irq_t *old = (irq_t *)src; 
+	irq_t *old = (irq_t *)src;
 	irq_t *new = malloc(sizeof(irq_t));
 	new->vector = old->vector;
 	new->load = old->load;

--- a/ui/irqbalance-ui.c
+++ b/ui/irqbalance-ui.c
@@ -146,9 +146,11 @@ void parse_setup(char *setup_data)
 
 	if(strncmp(token, "BANNED", strlen("BANNED"))) goto out;
 	token = strtok_r(ptr, " ", &ptr);
-	for(int i = strlen(token) - 1; i >= 0; i--) {
+    int i = 0;
+	for(i = strlen(token) - 1; i >= 0; i--) {
 		char *map = hex_to_bitmap(token[i]);
-		for(int j = 3; j >= 0; j--) {
+        int j = 0;
+		for(j = 3; j >= 0; j--) {
 			if(map[j] == '1') {
 				uint64_t *banned_cpu = malloc(sizeof(uint64_t));
 				*banned_cpu = (4 * (strlen(token) - (i + 1)) + (4 - (j + 1)));

--- a/ui/irqbalance-ui.c
+++ b/ui/irqbalance-ui.c
@@ -146,10 +146,10 @@ void parse_setup(char *setup_data)
 
 	if(strncmp(token, "BANNED", strlen("BANNED"))) goto out;
 	token = strtok_r(ptr, " ", &ptr);
-    int i = 0;
+	int i = 0;
 	for(i = strlen(token) - 1; i >= 0; i--) {
 		char *map = hex_to_bitmap(token[i]);
-        int j = 0;
+		int j = 0;
 		for(j = 3; j >= 0; j--) {
 			if(map[j] == '1') {
 				uint64_t *banned_cpu = malloc(sizeof(uint64_t));

--- a/ui/ui.c
+++ b/ui/ui.c
@@ -25,7 +25,8 @@ void show_frame()
 		snprintf(top + strlen(top), COLS - strlen(top), " ");
 	}
 	mvprintw(0, 0, top);
-	for(int i = 0; i < LINES; i++) {
+    int i = 0;
+	for(i = 0; i < LINES; i++) {
 		mvprintw(i, 0, " ");
 		mvprintw(i, COLS - 1, " ");
 	}
@@ -674,7 +675,8 @@ void display_tree_node(cpu_node_t *node, void *data)
 	char *spaces = "    \0";
 	char indent[32] = "\0";
 	char *asciitree = " `--\0";
-	for(int i = node->type; i <= OBJ_TYPE_NODE; i++) {
+    int i = 0;
+	for(i = node->type; i <= OBJ_TYPE_NODE; i++) {
 		snprintf(indent + strlen(indent), 32 - strlen(indent), "%s", spaces);
 		if(i != OBJ_TYPE_NODE) {
 			snprintf(indent + strlen(indent), 32 - strlen(indent), "   ");

--- a/ui/ui.c
+++ b/ui/ui.c
@@ -25,7 +25,7 @@ void show_frame()
 		snprintf(top + strlen(top), COLS - strlen(top), " ");
 	}
 	mvprintw(0, 0, top);
-    int i = 0;
+	int i = 0;
 	for(i = 0; i < LINES; i++) {
 		mvprintw(i, 0, " ");
 		mvprintw(i, COLS - 1, " ");
@@ -675,7 +675,7 @@ void display_tree_node(cpu_node_t *node, void *data)
 	char *spaces = "    \0";
 	char indent[32] = "\0";
 	char *asciitree = " `--\0";
-    int i = 0;
+	int i = 0;
 	for(i = node->type; i <= OBJ_TYPE_NODE; i++) {
 		snprintf(indent + strlen(indent), 32 - strlen(indent), "%s", spaces);
 		if(i != OBJ_TYPE_NODE) {


### PR DESCRIPTION
This pull request is with respect to the issue reported here:
https://github.com/Irqbalance/irqbalance/issues/43

There is some preprocessor magic that requires --std=c90 or older to build however there were some for loops using C99 syntax [i.e for(int i = 0; ...)]. This pull request switches these C99 style for loops to syntax compatible with older C standards, allowing irqbalance to build using the default CFLAGS generated by Autotools.