### PR TITLE
Teach irqbalance about Intel CoD

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -193,9 +193,14 @@ static void parse_command_line(int argc, char **argv)
 #endif
 
 /*
- * This builds our object tree.  The Heirarchy is pretty straightforward
+ * This builds our object tree.  The Heirarchy is typically pretty
+ * straightforward.
  * At the top are numa_nodes
- * All CPU packages belong to a single numa_node
+ * CPU packages belong to a single numa_node, unless the cache domains are in
+ * separate nodes.  In that case, the cache domain's parent is the package, but
+ * the numa nodes point to the cache domains instead of the package as their
+ * children.  This allows us to maintain the CPU hierarchy while adjusting for
+ * alternate memory topologies that are present on recent processor.
  * All Cache domains belong to a CPU package
  * All CPU cores belong to a cache domain
  *

--- a/irqbalance.c
+++ b/irqbalance.c
@@ -294,10 +294,12 @@ gboolean scan(gpointer data)
 		return FALSE;
 	}
 
-	if (keep_going)
+	if (keep_going) {
 		return TRUE;
-	else
+	} else {
+		g_main_loop_quit(main_loop);
 		return FALSE;
+	}
 }
 
 void get_irq_data(struct irq_info *irq, void *data)
@@ -585,7 +587,7 @@ int main(int argc, char** argv)
 	g_main_loop_run(main_loop);
 
 	g_main_loop_quit(main_loop);
-	
+
 	free_object_tree();
 	free_cl_opts();
 

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -84,26 +84,13 @@ extern long HZ;
 extern void build_numa_node_list(void);
 extern void free_numa_node_list(void);
 extern void dump_numa_node_info(struct topo_obj *node, void *data);
-extern void add_package_to_node(struct topo_obj *p, int nodeid);
+extern void connect_cpu_mem_topo(struct topo_obj *p, void *data);
 extern struct topo_obj *get_numa_node(int nodeid);
-
-/*
- * Package functions
- */
-#define package_numa_node(p) ((p)->parent)
-
-/*
- * cache_domain functions
- */
-#define cache_domain_package(c) ((c)->parent)
-#define cache_domain_numa_node(c) (package_numa_node(cache_domain_package((c))))
 
 /*
  * cpu core functions
  */
-#define cpu_cache_domain(cpu) ((cpu)->parent)
-#define cpu_package(cpu) (cache_domain_package(cpu_cache_domain((cpu))))
-#define cpu_numa_node(cpu) (package_numa_node(cache_domain_package(cpu_cache_domain((cpu)))))
+#define cpu_numa_node(cpu) ((cpu)->parent->numa_nodes)
 extern struct topo_obj *find_cpu_core(int cpunr);
 extern int get_cpu_count(void);
 

--- a/types.h
+++ b/types.h
@@ -54,6 +54,7 @@ struct topo_obj {
 	GList *interrupts;
 	struct topo_obj *parent;
 	GList *children;
+	GList *numa_nodes;
 	GList **obj_type_list;
 };
 


### PR DESCRIPTION
The Intel Cluster on Die topology breaks an existing assumption in irqbalance about the structure of the cpu and memory topology.  In CoD, it's possible for a physical package to have multiple NUMA domains.  In that case, irqbalance incorrectly constructs the topology in a way that strands one of the NUMA nodes.  This patch attempts to fix the problem by allowing NUMA nodes to point to the first portion of the CPU hierarchy where they are the unique.  At least with systems that the submitter has tested on, this turns out to be the LLC.