### PR TITLE
Change to Universal Analytics on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,17 +58,15 @@
       </footer>
     </div>
 
-              <script type="text/javascript">
-            var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-            document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-          </script>
-          <script type="text/javascript">
-            try {
-              var pageTracker = _gat._getTracker("UA-268719-3");
-            pageTracker._trackPageview();
-            } catch(err) {}
-          </script>
-
+    <!-- Google Analytics -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-26' + '87' + '19-3', 'auto');
+      ga('send', 'pageview');
+    </script>
 
   </body>
 </html>


### PR DESCRIPTION
> `ga('create', 'UA-26' + '87' + '19-3', 'auto');`

There are reverse-search databases for UA numbers. (`https://www.domainiq.com/reverse_analytics`)
