### PR TITLE
clean up aarch64 irq class guessing and pci bus skipping

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -711,18 +711,13 @@ static void add_new_irq(int irq, struct irq_info *hint, GList *proc_interrupts)
 	struct irq_info *new;
 	struct user_irq_policy pol;
 
-	printf("Adding missing irq %d\n", irq);
-
 	new = get_irq_info(irq);
-	if (new) {
-		printf("irq %d already has an entry\n", irq);
+	if (new)
 		return;
-	}
 
 	/* Set NULL devpath for the irq has no sysfs entries */
 	get_irq_user_policy(NULL, irq, &pol);
 	if ((pol.ban == 1) || check_for_irq_ban(NULL, irq, proc_interrupts)) { /*FIXME*/
-		printf("Adding irq %d as banned policy = %d\n", irq, pol.ban);
 		add_banned_irq(irq, &banned_irqs);
 		new = get_irq_info(irq);
 	} else
@@ -748,7 +743,7 @@ static void add_missing_irq(struct irq_info *info, void *attr)
 {
 	struct irq_info *lookup = get_irq_info(info->irq);
 	GList *proc_interrupts = (GList *) attr;
-	printf("Trying to add missing irq %d with lookup %p\n", info->irq, lookup);
+
 	if (!lookup)
 		add_new_irq(info->irq, info, proc_interrupts);
 }

--- a/classify.c
+++ b/classify.c
@@ -39,7 +39,7 @@ GList *cl_banned_irqs = NULL;
 static GList *cl_banned_modules = NULL;
 
 #define SYSFS_DIR "/sys"
-#define SYSDEV_DIR "/sys/bus/pci/devices"
+#define SYSPCI_DIR "/sys/bus/pci/devices"
 
 #define PCI_MAX_CLASS 0x14
 #define PCI_MAX_SERIAL_SUBCLASS 0x81
@@ -616,8 +616,8 @@ static void build_one_dev_entry(const char *dirname, GList *tmp_irqs)
 	char devpath[PATH_MAX];
 	struct user_irq_policy pol;
 
-	sprintf(path, "%s/%s/msi_irqs", SYSDEV_DIR, dirname);
-	sprintf(devpath, "%s/%s", SYSDEV_DIR, dirname);
+	sprintf(path, "%s/%s/msi_irqs", SYSPCI_DIR, dirname);
+	sprintf(devpath, "%s/%s", SYSPCI_DIR, dirname);
 	
 	msidir = opendir(path);
 
@@ -646,7 +646,7 @@ static void build_one_dev_entry(const char *dirname, GList *tmp_irqs)
 		return;
 	}
 
-	sprintf(path, "%s/%s/irq", SYSDEV_DIR, dirname);
+	sprintf(path, "%s/%s/irq", SYSPCI_DIR, dirname);
 	fd = fopen(path, "r");
 	if (!fd)
 		return;
@@ -764,22 +764,21 @@ void rebuild_irq_db(void)
 
 	tmp_irqs = collect_full_irq_list();
 
-	devdir = opendir(SYSDEV_DIR);
-	if (!devdir)
-		goto free;
+	devdir = opendir(SYSPCI_DIR);
 
-	do {
-		entry = readdir(devdir);
+	if (devdir) {
+		do {
+			entry = readdir(devdir);
 
-		if (!entry)
-			break;
+			if (!entry)
+				break;
 
-		build_one_dev_entry(entry->d_name, tmp_irqs);
+			build_one_dev_entry(entry->d_name, tmp_irqs);
 
-	} while (entry != NULL);
+		} while (entry != NULL);
 
-	closedir(devdir);
-
+		closedir(devdir);
+	}
 
 	for_each_irq(tmp_irqs, add_missing_irq, interrupts_db);
 

--- a/classify.c
+++ b/classify.c
@@ -711,13 +711,18 @@ static void add_new_irq(int irq, struct irq_info *hint, GList *proc_interrupts)
 	struct irq_info *new;
 	struct user_irq_policy pol;
 
+	printf("Adding missing irq %d\n", irq);
+
 	new = get_irq_info(irq);
-	if (new)
+	if (new) {
+		printf("irq %d already has an entry\n", irq);
 		return;
+	}
 
 	/* Set NULL devpath for the irq has no sysfs entries */
 	get_irq_user_policy(NULL, irq, &pol);
 	if ((pol.ban == 1) || check_for_irq_ban(NULL, irq, proc_interrupts)) { /*FIXME*/
+		printf("Adding irq %d as banned policy = %d\n", irq, pol.ban);
 		add_banned_irq(irq, &banned_irqs);
 		new = get_irq_info(irq);
 	} else
@@ -743,7 +748,7 @@ static void add_missing_irq(struct irq_info *info, void *attr)
 {
 	struct irq_info *lookup = get_irq_info(info->irq);
 	GList *proc_interrupts = (GList *) attr;
-
+	printf("Trying to add missing irq %d with lookup %p\n", info->irq, lookup);
 	if (!lookup)
 		add_new_irq(info->irq, info, proc_interrupts);
 }

--- a/irqbalance.c
+++ b/irqbalance.c
@@ -262,7 +262,6 @@ gboolean force_rescan(gpointer data __attribute__((unused)))
 {
 	if (cycle_count)
 		need_rescan = 1;
-	printf("FORCING RESCAN VIA SIGHUP!\n");
 	return TRUE;
 }
 
@@ -432,7 +431,6 @@ gboolean sock_handle(gint fd, GIOCondition condition, gpointer user_data __attri
 				g_list_free_full(cl_banned_irqs, free);
 				cl_banned_irqs = NULL;
 				need_rescan = 1;
-				printf("RESCANNING FROM SOCKET 1\n");
 				if (!strncmp(irq_string, "NONE", strlen("NONE"))) {
 					return TRUE;
 				}
@@ -450,7 +448,6 @@ gboolean sock_handle(gint fd, GIOCondition condition, gpointer user_data __attri
 				if (!strncmp(banned_cpumask_from_ui, "NULL", strlen("NULL"))) {
 					banned_cpumask_from_ui = NULL;
 				}
-				printf("RESCANNING FROM SOCKET 2\n");
 				need_rescan = 1;
 			}
 		}

--- a/irqbalance.c
+++ b/irqbalance.c
@@ -262,6 +262,7 @@ gboolean force_rescan(gpointer data __attribute__((unused)))
 {
 	if (cycle_count)
 		need_rescan = 1;
+	printf("FORCING RESCAN VIA SIGHUP!\n");
 	return TRUE;
 }
 
@@ -431,6 +432,7 @@ gboolean sock_handle(gint fd, GIOCondition condition, gpointer user_data __attri
 				g_list_free_full(cl_banned_irqs, free);
 				cl_banned_irqs = NULL;
 				need_rescan = 1;
+				printf("RESCANNING FROM SOCKET 1\n");
 				if (!strncmp(irq_string, "NONE", strlen("NONE"))) {
 					return TRUE;
 				}
@@ -448,6 +450,7 @@ gboolean sock_handle(gint fd, GIOCondition condition, gpointer user_data __attri
 				if (!strncmp(banned_cpumask_from_ui, "NULL", strlen("NULL"))) {
 					banned_cpumask_from_ui = NULL;
 				}
+				printf("RESCANNING FROM SOCKET 2\n");
 				need_rescan = 1;
 			}
 		}

--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -263,7 +263,6 @@ void parse_proc_interrupts(void)
 				proc_int_has_msi = 1;
 
 		/* lines with letters in front are special, like NMI count. Ignore */
-		printf("parsing proc interrupts line: %s\n", line);
 		c = line;
 		while (isblank(*(c)))
 			c++;

--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -282,7 +282,6 @@ void parse_proc_interrupts(void)
 
 		info = get_irq_info(number);
 		if (!info) {
-			printf("CANT FIND INFO FOR irq %d, RESCANNING\n", number);
 			need_rescan = 1;
 			break;
 		}
@@ -301,7 +300,6 @@ void parse_proc_interrupts(void)
 			cpunr++;
 		}
 		if (cpunr != core_count) {
-			printf("CPU COUNT CHANGED FROM %d to %d, RESCANNING\n", core_count, cpunr);
 			need_rescan = 1;
 			break;
 		}
@@ -310,7 +308,6 @@ void parse_proc_interrupts(void)
 		 * cause an overflow and IRQ won't be rebalanced again
 		 */
 		if (count < info->irq_count) {
-			printf("IRQ %d count regressed from %d to %d, RESCANNING\n", info->irq, info->irq_count, count);
 			need_rescan = 1;
 			break;
 		}

--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -281,6 +281,7 @@ void parse_proc_interrupts(void)
 
 		info = get_irq_info(number);
 		if (!info) {
+			printf("CANT FIND INFO FOR irq %d, RESCANNING\n", number);
 			need_rescan = 1;
 			break;
 		}
@@ -299,6 +300,7 @@ void parse_proc_interrupts(void)
 			cpunr++;
 		}
 		if (cpunr != core_count) {
+			printf("CPU COUNT CHANGED FROM %d to %d, RESCANNING\n", core_count, cpunr);
 			need_rescan = 1;
 			break;
 		}
@@ -307,6 +309,7 @@ void parse_proc_interrupts(void)
 		 * cause an overflow and IRQ won't be rebalanced again
 		 */
 		if (count < info->irq_count) {
+			printf("IRQ %d count regressed from %d to %d, RESCANNING\n", info->irq, info->irq_count, count);
 			need_rescan = 1;
 			break;
 		}

--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -105,10 +105,12 @@ static void guess_arm_irq_hints(char *name, struct irq_info *info)
 {
 	int i, rc;
 	static int compiled = 0;
+	/* Note: Last entry is a catchall */
 	static struct irq_match matches[] = {
 		{ "eth.*" ,{NULL} ,NULL, IRQ_TYPE_LEGACY, IRQ_GBETH },
 		{ "[A-Z0-9]{4}[0-9a-f]{4}", {NULL} ,check_platform_device, IRQ_TYPE_LEGACY, IRQ_OTHER},
 		{ "PNP[0-9a-f]{4}", {NULL} ,check_platform_device, IRQ_TYPE_LEGACY, IRQ_OTHER},
+		{ ".*", {NULL}, NULL, IRQ_TYPE_LEGACY, IRQ_OTHER},
 		{NULL},
 	};
 
@@ -134,8 +136,7 @@ static void guess_arm_irq_hints(char *name, struct irq_info *info)
 			info->class = matches[i].class;
 			if (matches[i].refine_match)
 			    matches[i].refine_match(name, info);
-
-			log(TO_ALL, LOG_DEBUG, "IRQ %s(%d) is class %d\n", name, info->irq,info->class);
+			log(TO_ALL, LOG_DEBUG, "IRQ %s(%d) guessed as class %d\n", name, info->irq,info->class);
 		}	
 	}
 	
@@ -214,7 +215,6 @@ GList* collect_full_irq_list()
 				info->class = IRQ_VIRT_EVENT;
 			} else {
 #ifdef AARCH64
-				log(TO_ALL, LOG_DEBUG, "GUESSING AARCH64 CLASS FOR %s\n", irq_name);
 				guess_arm_irq_hints(irq_name, info);
 #else
 				info->type = IRQ_TYPE_LEGACY;

--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -263,6 +263,7 @@ void parse_proc_interrupts(void)
 				proc_int_has_msi = 1;
 
 		/* lines with letters in front are special, like NMI count. Ignore */
+		printf("parsing proc interrupts line: %s\n", line);
 		c = line;
 		while (isblank(*(c)))
 			c++;


### PR DESCRIPTION
the scanning code for /proc/interrupts has an issue whereby, if the system doesn't contain a pci bus, all other interrupts are skipped in their addition to the irq database.  This means nothing gets balanced, and we constantly just rescan.  This is often a problem on small aarch64 systems, which often don't have a pci bus.  This branch fixes that by always adding the non - pci bus interrupts to the db.  It also does some cleanup of the aarch64 irq class guessing code while I'm in there.