### PR TITLE
Service file improvements

### DIFF
--- a/misc/irqbalance.service
+++ b/misc/irqbalance.service
@@ -7,6 +7,12 @@ ConditionVirtualization=!container
 [Service]
 EnvironmentFile=/path/to/irqbalance.env
 ExecStart=/usr/sbin/irqbalance --foreground $IRQBALANCE_ARGS
+CapabilityBoundingSet=
+NoNewPrivileges=yes
+ReadOnlyPaths=/
+ReadWritePaths=/proc/irq
+RestrictAddressFamilies=AF_UNIX
+TemporaryFileSystem=/run:ro
 
 [Install]
 WantedBy=multi-user.target

--- a/misc/irqbalance.service
+++ b/misc/irqbalance.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=irqbalance daemon
+Documentation=man:irqbalance(1)
+Documentation=https://github.com/Irqbalance/irqbalance
 ConditionVirtualization=!container
 
 [Service]


### PR DESCRIPTION
See individual commit messages.

---

The sandbox is not perfect: if an attacker gains arbitrary code execution in `irqbalance`, they can still, for example, read any file owned by root¹ (`/etc/shadow`, `/etc/ssh/ssh_host_rsa_key`, etc.) and encode it inside files in `/proc/irq`², where another unprivileged process also controlled by the attacker could read it and publish it over the network. But I think the unit file would become too unwieldy if we added too many more directives – this should already provide a lot of protection at little cost.

¹: Without `CAP_DAC_READ_SEARCH`, it can’t read files that are owned by other users and not world-readable (e. g. stuff in `/home`), but files owned by root can be read without any special capabilities.
²: The kernel won’t let you create arbitrary files in `/proc/irq` (`ENOENT`) nor write arbitrary text to existing files there (`EIO`), but you could still send messages by encoding them over time, byte by byte, in the affinities for various IRQs.

---

I’m currently running a more aggressive version of this sandbox (https://github.com/lucaswerkmeister/server-etc/commit/38f3b87d5b4d48ed98c96980ea3dfc959f2a12bc) on my server, and so far it seems to work fine.