### PR TITLE
Expansion of policy scripting

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -569,36 +569,6 @@ static int check_for_irq_ban(char *path __attribute__((unused)), int irq, GList 
 			return 1;
 	}
 
-#ifdef INCLUDE_BANSCRIPT
-	char *cmd;
-	int rc;
-
-	if (!banscript)
-		return 0;
-
-	if (!path)
-		return 0;
-
-	cmd = alloca(strlen(path)+strlen(banscript)+32);
-	if (!cmd)
-		return 0;
-	
-	sprintf(cmd, "%s %s %d > /dev/null",banscript, path, irq);
-	rc = system(cmd);
-
-	/*
- 	 * The system command itself failed
- 	 */
-	if (rc == -1) {
-		log(TO_ALL, LOG_WARNING, "%s failed, please check the --banscript option\n", cmd);
-		return 0;
-	}
-
-	if (WEXITSTATUS(rc)) {
-		log(TO_ALL, LOG_INFO, "irq %d is baned by %s\n", irq, banscript);
-		return 1;
-	}
-#endif
 	return 0;
 }
 

--- a/classify.c
+++ b/classify.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <dirent.h>
 #include <assert.h>
 #include <errno.h>
@@ -493,37 +494,22 @@ static void parse_user_policy_key(char *buf, int irq, struct user_irq_policy *po
 	
 }
 
-/*
- * Calls out to a possibly user defined script to get user assigned policy
- * aspects for a given irq.  A value of -1 in a given field indicates no
- * policy was given and that system defaults should be used
- */
-static void get_irq_user_policy(char *path, int irq, struct user_irq_policy *pol)
+static int run_script_for_policy(char *script, char *path, int irq, struct user_irq_policy *pol)
 {
 	char *cmd;
+	char *brc;
 	FILE *output;
 	char buffer[128];
-	char *brc;
 
-	memset(pol, -1, sizeof(struct user_irq_policy));
-
-	/* Return defaults if no script was given */
-	if (!polscript)
-		return;
-
-	/* Use SYSFS_DIR for irq has no sysfs entries */
-	if (!path)
-		path = SYSFS_DIR;
-
-	cmd = alloca(strlen(path)+strlen(polscript)+64);
+	cmd = alloca(strlen(path)+strlen(script)+64);
 	if (!cmd)
-		return;
+		return -1;
 
-	sprintf(cmd, "exec %s %s %d", polscript, path, irq);
+	sprintf(cmd, "exec %s %s %d", script, path, irq);
 	output = popen(cmd, "r");
 	if (!output) {
-		log(TO_ALL, LOG_WARNING, "Unable to execute user policy script %s\n", polscript);
-		return;
+		log(TO_ALL, LOG_WARNING, "Unable to execute user policy script %s\n", script);
+		return 1; /* tell caller to ignore this script */
 	}
 
 	while(!feof(output)) {
@@ -531,7 +517,69 @@ static void get_irq_user_policy(char *path, int irq, struct user_irq_policy *pol
 		if (brc)
 			parse_user_policy_key(brc, irq, pol);
 	}
-	pclose(output);
+	return WEXITSTATUS(pclose(output));
+}
+
+/*
+ * Calls out to a possibly user defined script to get user assigned policy
+ * aspects for a given irq.  A value of -1 in a given field indicates no
+ * policy was given and that system defaults should be used
+ */
+static void get_irq_user_policy(char *path, int irq, struct user_irq_policy *pol)
+{
+	struct stat sbuf;
+	DIR *poldir;
+	struct dirent *entry;
+	int ret;
+	char script[1024];
+
+	memset(pol, -1, sizeof(struct user_irq_policy));
+
+	/* Return defaults if no script was given */
+	if (!polscript)
+		return;
+
+	if (stat(polscript, &sbuf))
+		return;
+
+	/* Use SYSFS_DIR for irq has no sysfs entries */
+	if (!path)
+		path = SYSFS_DIR;
+
+	if (!S_ISDIR(sbuf.st_mode)) {
+		if (run_script_for_policy(polscript, path, irq, pol) != 0) {
+			log(TO_CONSOLE, LOG_ERR, "policy script returned non-zero code!  skipping user policy\n");
+			memset(pol, -1, sizeof(struct user_irq_policy));
+		}
+	} else {
+		/* polscript is a directory, user multiple script semantics */
+		poldir = opendir(polscript);
+
+		if (poldir) {
+			while ((entry = readdir(poldir)) != NULL) {
+				snprintf(script, sizeof(script), "%s/%s", polscript, entry->d_name);
+				if (stat(script, &sbuf))
+					continue;
+				if (S_ISREG(sbuf.st_mode)) {
+					memset(pol, -1, sizeof(struct user_irq_policy));
+					ret = run_script_for_policy(script, path, irq, pol);
+					if ((ret < 0) || (ret >= 2)) {
+						log(TO_CONSOLE, LOG_ERR, "Error executing policy script %s : %d\n", script, ret);
+						continue;
+					}
+
+					/* a ret of 1 means this script isn't
+ 					 * for this irq
+ 					 */
+					if (ret == 1)
+						continue;
+
+					log(TO_CONSOLE, LOG_DEBUG, "Accepting script %s to define policy for irq %d\n", script, irq);
+					break;
+				}
+			}
+		}
+	}
 }
 
 static int check_for_module_ban(char *name)

--- a/irqbalance.1
+++ b/irqbalance.1
@@ -80,7 +80,7 @@ The default value for deepestcache is 2.
 
 .TP
 .B -l, --policyscript=<script>
-When specified, the referenced script will execute once for each discovered IRQ,
+When specified, the referenced script or directory will execute once for each discovered IRQ,
 with the sysfs device path and IRQ number passed as arguments.  Note that the
 device path argument will point to the parent directory from which the IRQ
 attributes directory may be directly opened.
@@ -90,7 +90,6 @@ and will be captured and interpreted by irqbalance.  Irqbalance expects a zero
 exit code from the provided utility.  Recognized key=value pairs are:
 .TP
 .I ban=[true | false]
-.TP
 Directs irqbalance to exclude the passed in IRQ from balancing.
 .TP
 .I balance_level=[none | package | cache | core]
@@ -106,6 +105,24 @@ This option allows for that hardware provided information to be overridden, so
 that irqbalance can bias IRQ affinity for these devices toward its most local
 node.  Note that specifying a -1 here forces irqbalance to consider an interrupt
 from a device to be equidistant from all nodes.
+.TP
+Note that, if a directory is specified rather than a regular file, all files in
+the directory will be considered policy scripts, and executed on adding of an
+irq to a database.  If such a directory is specified, scripts in the directory
+must additionally exit with one of the following exit codes:
+.TP
+.I 0
+This indicates the script has a policy for the referenced irq, and that further
+script processing should stop
+.TP
+.I 1
+This indicates that the script has no policy for the referenced irq, and that
+script processing should continue
+.TP
+.I 2
+This indicates that an error has occured in the script, and it should be skipped
+(further processing to continue)
+
 .TP
 .B -s, --pid=<file>
 Have irqbalance write its process id to the specified file.  By default no

--- a/irqbalance.c
+++ b/irqbalance.c
@@ -57,7 +57,6 @@ unsigned long power_thresh = ULONG_MAX;
 unsigned long deepest_cache = 2;
 unsigned long long cycle_count = 0;
 char *pidfile = NULL;
-char *banscript = NULL;
 char *polscript = NULL;
 long HZ;
 int sleep_interval = SLEEP_INTERVAL;
@@ -87,7 +86,6 @@ struct option lopts[] = {
 	{"hintpolicy", 1, NULL, 'h'},
 	{"powerthresh", 1, NULL, 'p'},
 	{"banirq", 1 , NULL, 'i'},
-	{"banscript", 1, NULL, 'b'},
 	{"deepestcache", 1, NULL, 'c'},
 	{"policyscript", 1, NULL, 'l'},
 	{"pid", 1, NULL, 's'},
@@ -117,7 +115,7 @@ static void parse_command_line(int argc, char **argv)
 	unsigned long val;
 
 	while ((opt = getopt_long(argc, argv,
-		"odfji:p:s:c:b:l:m:t:V",
+		"odfji:p:s:c:l:m:t:V",
 		lopts, &longind)) != -1) {
 
 		switch(opt) {
@@ -128,18 +126,6 @@ static void parse_command_line(int argc, char **argv)
 			case 'V':
 				version();
 				exit(1);
-				break;
-			case 'b':
-#ifndef INCLUDE_BANSCRIPT
-				/*
-				 * Banscript is no longer supported unless
-				 * explicitly enabled
-				 */
-				log(TO_CONSOLE, LOG_INFO, "--banscript is not supported on this version of irqbalance, please use --policyscript\n");
-				usage();
-				exit(1);
-#endif
-				banscript = strdup(optarg);
 				break;
 			case 'c':
 				deepest_cache = strtoul(optarg, NULL, 10);
@@ -559,11 +545,6 @@ int main(int argc, char** argv)
 
 	if (geteuid() != 0)
 		log(TO_ALL, LOG_WARNING, "Irqbalance hasn't been executed under root privileges, thus it won't in fact balance interrupts.\n");
-
-	if (banscript) {
-		char *note = "Please note that --banscript is deprecated, please use --policyscript instead";
-		log(TO_ALL, LOG_WARNING, "%s\n", note);
-	}
 
 	HZ = sysconf(_SC_CLK_TCK);
 	if (HZ == -1) {

--- a/irqbalance.c
+++ b/irqbalance.c
@@ -468,8 +468,7 @@ int init_socket(char *socket_name)
 	}
 
 	addr.sun_family = AF_UNIX;
-	addr.sun_path[0] = '\0';
-	strncpy(addr.sun_path + 1, socket_name, strlen(socket_name));
+	strncpy(addr.sun_path, socket_name, strlen(addr.sun_path));
 	if (bind(socket_fd, (struct sockaddr *)&addr,
 				sizeof(sa_family_t) + strlen(socket_name) + 1) < 0) {
 		log(TO_ALL, LOG_WARNING, "Daemon couldn't be bound to the socket.\n");

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -72,7 +72,6 @@ extern int need_rescan;
 extern unsigned long long cycle_count;
 extern unsigned long power_thresh;
 extern unsigned long deepest_cache;
-extern char *banscript;
 extern char *polscript;
 extern cpumask_t banned_cpus;
 extern cpumask_t unbanned_cpus;

--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -274,7 +274,7 @@ void parse_proc_interrupts(void)
 		if (!c)
 			continue;
 
-		strncpy(savedline, line, sizeof(savedline));
+		strncpy(savedline, line, sizeof(savedline)-1);
 
 		*c = 0;
 		c++;

--- a/ui/irqbalance-ui.c
+++ b/ui/irqbalance-ui.c
@@ -57,7 +57,7 @@ int init_connection()
 	addr.sun_family = AF_UNIX;
 	char socket_name[64];
 	snprintf(socket_name, 64, "%s%d.sock", SOCKET_PATH, irqbalance_pid);
-	strncpy(addr.sun_path + 1, socket_name, strlen(socket_name));
+	strncpy(addr.sun_path, socket_name, strlen(addr.sun_path));
 
 	if(connect(socket_fd, (struct sockaddr *)&addr,
 				sizeof(sa_family_t) + strlen(socket_name) + 1) < 0) {


### PR DESCRIPTION
This feature enhances our policy script feature.  Currently irqbalance has the ability to use a single policy script, which must contain the logic to properly handle/ignore all devices, which is less than ideal.  This feature enhances policyscripting to allow for a directory to be specified that holds multiple scripts, that can control individual devices.  The idea being that if a IHV creates a device that needs special irqbalance policy, they can submit a script for inclusion that detects only their device and handles it accordingly.