### PR TITLE
irqbalance: Add support for file-based socket for IPC

### DIFF
--- a/irqbalance.h
+++ b/irqbalance.h
@@ -158,6 +158,7 @@ extern unsigned int log_mask;
 #endif /* HAVE_LIBSYSTEMD */
 
 #define SOCKET_PATH "irqbalance"
+#define SOCKET_TMPFS "/var/run"
 
 #endif /* __INCLUDE_GUARD_IRQBALANCE_H_ */
 


### PR DESCRIPTION
This patch adds support for a file-based socket in tmpfs. It
also fixes an inadvertent bug that caused the socket in use to
be an abstract socket, which wasn't the intent.

This addresses Issue #72.

Signed-off-by: PJ Waskiewicz <pjwaskiewicz@gmail.com>