### PR TITLE
Fix irqbalance ui failing to connect to irqbalance daemon

### DIFF
--- a/ui/irqbalance-ui.c
+++ b/ui/irqbalance-ui.c
@@ -57,12 +57,18 @@ int init_connection()
 	}
 	addr.sun_family = AF_UNIX;
 	char socket_name[64];
-	snprintf(socket_name, 64, "%s%d.sock", SOCKET_PATH, irqbalance_pid);
-	strncpy(addr.sun_path, socket_name, strlen(addr.sun_path));
 
-	if(connect(socket_fd, (struct sockaddr *)&addr,
-				sizeof(sa_family_t) + strlen(socket_name) + 1) < 0) {
-		return 0;
+	snprintf(socket_name, 64, "%s/%s%d.sock", SOCKET_TMPFS, SOCKET_PATH, irqbalance_pid);
+	strncpy(addr.sun_path, socket_name, strlen(socket_name));
+
+	if(connect(socket_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		/* Try connect to abstract */
+		memset(&addr, 0, sizeof(struct sockaddr_un));
+		addr.sun_family = AF_UNIX;
+		if (connect(socket_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+			return 0;
+		}
+
 	}
 
 	return socket_fd;

--- a/ui/irqbalance-ui.h
+++ b/ui/irqbalance-ui.h
@@ -8,6 +8,7 @@
 #include <glib-unix.h>
 
 #define SOCKET_PATH "irqbalance"
+#define SOCKET_TMPFS "/var/run"
 
 #define STATS "stats"
 #define SET_SLEEP "settings sleep "


### PR DESCRIPTION
irqbalance ui is faling due to the changes in commit 19c25dd.
This patch align irqbalance-ui's socket connecting routine with
irqbalance.c