### PR TITLE
policyscript: ignore non-executable files when specifying a directory

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -561,6 +561,11 @@ static void get_irq_user_policy(char *path, int irq, struct user_irq_policy *pol
 				if (stat(script, &sbuf))
 					continue;
 				if (S_ISREG(sbuf.st_mode)) {
+					if (!(sbuf.st_mode & S_IXUSR)) {
+						log(TO_CONSOLE, LOG_DEBUG, "Skipping script %s due to lack of executable permission\n", script);
+						continue;
+					}
+
 					memset(pol, -1, sizeof(struct user_irq_policy));
 					ret = run_script_for_policy(script, path, irq, pol);
 					if ((ret < 0) || (ret >= 2)) {

--- a/irqbalance.1
+++ b/irqbalance.1
@@ -84,6 +84,8 @@ When specified, the referenced script or directory will execute once for each di
 with the sysfs device path and IRQ number passed as arguments.  Note that the
 device path argument will point to the parent directory from which the IRQ
 attributes directory may be directly opened.
+Policy scripts specified need to be owned and executable by the user of irqbalance process,
+if a directory is specified, non-executable files will be skipped.
 The script may specify zero or more key=value pairs that will guide irqbalance in
 the management of that IRQ.  Key=value pairs are printed by the script on stdout
 and will be captured and interpreted by irqbalance.  Irqbalance expects a zero


### PR DESCRIPTION
Currenly irqbalance require custom scirpts to be executable. If a
non-executable file is found, irqbalance will stil try to execute it but
fail with no permission error.

So just ignore non-executable file, this also make is possible to have
non-executable files in policyscript directory as reference.