### PR TITLE
systemd: add prefixed with "-" to EnviromentFile.

### DIFF
--- a/misc/irqbalance.service
+++ b/misc/irqbalance.service
@@ -5,7 +5,7 @@ Documentation=https://github.com/Irqbalance/irqbalance
 ConditionVirtualization=!container
 
 [Service]
-EnvironmentFile=/path/to/irqbalance.env
+EnvironmentFile=-/path/to/irqbalance.env
 ExecStart=/usr/sbin/irqbalance --foreground $IRQBALANCE_ARGS
 CapabilityBoundingSet=
 NoNewPrivileges=yes


### PR DESCRIPTION
- When failing to read the env file, do not judge it as a failure.
- https://www.freedesktop.org/software/systemd/man/systemd.exec.html

It is intended to prevent errors from forgetting to fix the file path as it is.
This is because we think that importing EnvironmetFile is not mandatory.