### PR TITLE
Fix string truncation issues detected by GCC 8

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -482,7 +482,7 @@ int init_socket()
 	 */
 	addr.sun_family = AF_UNIX;
 	snprintf(socket_name, 64, "%s/%s%d.sock", SOCKET_TMPFS, SOCKET_PATH, getpid());
-	strncpy(addr.sun_path, socket_name, strlen(socket_name));
+	strncpy(addr.sun_path, socket_name, sizeof(addr.sun_path));
 	if (bind(socket_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 		log(TO_ALL, LOG_WARNING, "Daemon couldn't be bound to the file-based socket.\n");
 

--- a/ui/irqbalance-ui.c
+++ b/ui/irqbalance-ui.c
@@ -56,10 +56,9 @@ int init_connection()
 		return 0;
 	}
 	addr.sun_family = AF_UNIX;
-	char socket_name[64];
 
-	snprintf(socket_name, 64, "%s/%s%d.sock", SOCKET_TMPFS, SOCKET_PATH, irqbalance_pid);
-	strncpy(addr.sun_path, socket_name, strlen(socket_name));
+	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s/%s%d.sock", SOCKET_TMPFS,
+		 SOCKET_PATH, irqbalance_pid);
 
 	if(connect(socket_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 		/* Try connect to abstract */


### PR DESCRIPTION
This fixes string truncation warning generated by GCC of the form:

irqbalance.c:485:2: warning: 'strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  strncpy(addr.sun_path, socket_name, strlen(socket_name));
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Using source size in strncpy so fix that by using destination size.
For the instance of this issue in irqbalance-ui.c, fix the issue by
eliminating the unneeded temporary buffer.

Signed-off-by: Sekhar Nori <nsekhar@ti.com>