### PR TITLE
Refine document about IRQBALANCE_BANNED_CPUS

### DIFF
--- a/irqbalance.1
+++ b/irqbalance.1
@@ -155,6 +155,8 @@ Same as --debug.
 .TP
 .B IRQBALANCE_BANNED_CPUS
 Provides a mask of CPUs which irqbalance should ignore and never assign interrupts to.
+If not specified, irqbalance use mask of isolated and adaptive-ticks CPUs on the
+system as the default value.
 
 .SH "SIGNALS"
 .TP


### PR DESCRIPTION
There is no declaration about how irqbalance deal with isolated CPUs or
adaptive-ticks CPUs, and how IRQBALANCE_BANNED_CPUS will override the
behavior of auto-banning of such CPUs. Refine the document to avoid
confusion.

Signed-off-by: Kairui Song <kasong@redhat.com>