### PR TITLE
Remove a duplicated word in manpage

### DIFF
--- a/irqbalance.1
+++ b/irqbalance.1
@@ -178,7 +178,7 @@ each assigned IRQ type, it's number, load, number of IRQs since last rebalancing
 and it's class are sent. Refer to types.h file for explanation of defines.
 .TP
 .B setup
-Get the current value of sleep interval, mask of banned CPUs and and list of banned IRQs.
+Get the current value of sleep interval, mask of banned CPUs and list of banned IRQs.
 .TP
 .B settings sleep <s>
 Set new value of sleep interval, <s> >= 1.


### PR DESCRIPTION
Just noticed this waning in a manpage scan report, trivial but let's
fix it.

Signed-off-by: Kairui Song <kasong@redhat.com>