### PR TITLE
Fix typo in procinterrupts

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -438,7 +438,7 @@ void parse_proc_stat(void)
 
 	file = fopen("/proc/stat", "r");
 	if (!file) {
-		log(TO_ALL, LOG_WARNING, "WARNING cant open /proc/stat.  balacing is broken\n");
+		log(TO_ALL, LOG_WARNING, "WARNING cant open /proc/stat.  balancing is broken\n");
 		return;
 	}
 


### PR DESCRIPTION
The word blacing should be blancing

Signed-off-by: Neil Horman <nhorman@tuxdriver.com>
Reported-by: Edward Arthur <ed.arthur@gmail.com>