### PR TITLE
a hole that may flees hotplug event.

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -270,9 +270,9 @@ gboolean scan(gpointer data)
 		for_each_irq(NULL, force_rebalance_irq, NULL);
 		parse_proc_interrupts();
 		parse_proc_stat();
-		sleep_approx(sleep_interval);
-		clear_work_stats();
-		parse_proc_interrupts();
+
+		/* Still need to check hotplugged or not next round */
+		return TRUE;
 	}
 
 	parse_proc_stat();


### PR DESCRIPTION
in parse_proc_interrupts, irqbalance will set the global var need_rescan to 1 if a hot plug event occured. and in scan, if need_rescan == 1, it will clear the irq db and rescan the interrupts:
		parse_proc_interrupts();
		parse_proc_stat();
		sleep_approx(sleep_interval);
		clear_work_stats();
		parse_proc_interrupts();
a probalble issue is: hot pulg event may occured again, and
need_rescan may be set to 1 again. in such situation, interrupts need to be
rescaned but not. so there may be a hole that flees hotplug event.

I think a possible solution is return TRUE instead of going down
directly in the need_rescan branch.

Xiashuang <xiashuang1@huawei.com>