### PR TITLE
fix guess_arm_irq_hints

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -137,6 +137,7 @@ static void guess_arm_irq_hints(char *name, struct irq_info *info)
 			if (matches[i].refine_match)
 			    matches[i].refine_match(name, info);
 			log(TO_ALL, LOG_DEBUG, "IRQ %s(%d) guessed as class %d\n", name, info->irq,info->class);
+			break;
 		}	
 	}
 	


### PR DESCRIPTION
in aarch64, irqbalance will guess irq's class and type according to
irq's name, but it did't work properly now, a irq's name will be
matched twice and class will always be IRQ_OTHER. such as a nic
interrupt, the debug log will be:
	IRQ eth3-tx0 (109) guessed as class 5
	IRQ eth3-tx0 (109) guessed as class 0
irq's class should be IRQ_GBETH but is IRQ_OTHER.