### PR TITLE
make the return value of getline() handled correct

### DIFF
--- a/activate.c
+++ b/activate.c
@@ -44,7 +44,7 @@ static int check_affinity(struct irq_info *info, cpumask_t applied_mask)
 	file = fopen(buf, "r");
 	if (!file)
 		return 1;
-	if (getline(&line, &size, file)==0) {
+	if (getline(&line, &size, file)<=0) {
 		free(line);
 		fclose(file);
 		return 1;

--- a/cputree.c
+++ b/cputree.c
@@ -278,7 +278,7 @@ static void do_one_cpu(char *path)
 	if (file) {
 		char *line = NULL;
 		size_t size = 0;
-		if (getline(&line, &size, file)==0)
+		if (getline(&line, &size, file)<=0)
 			return;
 		fclose(file);
 		if (line && line[0]=='0') {
@@ -323,7 +323,7 @@ static void do_one_cpu(char *path)
 	if (file) {
 		char *line = NULL;
 		size_t size = 0;
-		if (getline(&line, &size, file)) 
+		if (getline(&line, &size, file) > 0)
 			cpumask_parse_user(line, strlen(line), package_mask);
 		fclose(file);
 		free(line);
@@ -335,7 +335,7 @@ static void do_one_cpu(char *path)
 	if (file) {
 		char *line = NULL;
 		size_t size = 0;
-		if (getline(&line, &size, file))
+		if (getline(&line, &size, file) > 0)
 			packageid = strtoul(line, NULL, 10);
 		fclose(file);
 		free(line);
@@ -368,7 +368,7 @@ static void do_one_cpu(char *path)
 		if (file) {
 			char *line = NULL;
 			size_t size = 0;
-			if (getline(&line, &size, file))
+			if (getline(&line, &size, file) > 0)
 				cpumask_parse_user(line, strlen(line), cache_mask);
 			fclose(file);
 			free(line);

--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -161,7 +161,7 @@ GList* collect_full_irq_list()
 		return NULL;
 
 	/* first line is the header we don't need; nuke it */
-	if (getline(&line, &size, file)==0) {
+	if (getline(&line, &size, file)<=0) {
 		free(line);
 		fclose(file);
 		return NULL;
@@ -174,7 +174,7 @@ GList* collect_full_irq_list()
 		char *c;
 		char *savedline = NULL;
 
-		if (getline(&line, &size, file)==0)
+		if (getline(&line, &size, file)<=0)
 			break;
 
 		/* lines with letters in front are special, like NMI count. Ignore */
@@ -248,7 +248,7 @@ void parse_proc_interrupts(void)
 		return;
 
 	/* first line is the header we don't need; nuke it */
-	if (getline(&line, &size, file)==0) {
+	if (getline(&line, &size, file)<=0) {
 		free(line);
 		fclose(file);
 		return;
@@ -262,7 +262,7 @@ void parse_proc_interrupts(void)
 		struct irq_info *info;
 		char savedline[1024];
 
-		if (getline(&line, &size, file)==0)
+		if (getline(&line, &size, file)<=0)
 			break;
 
 		if (!proc_int_has_msi)
@@ -444,7 +444,7 @@ void parse_proc_stat(void)
 	}
 
 	/* first line is the header we don't need; nuke it */
-	if (getline(&line, &size, file)==0) {
+	if (getline(&line, &size, file)<=0) {
 		free(line);
 		log(TO_ALL, LOG_WARNING, "WARNING read /proc/stat. balancing is broken\n");
 		fclose(file);
@@ -453,7 +453,7 @@ void parse_proc_stat(void)
 
 	cpucount = 0;
 	while (!feof(file)) {
-		if (getline(&line, &size, file)==0)
+		if (getline(&line, &size, file)<=0)
 			break;
 
 		if (!strstr(line, "cpu"))


### PR DESCRIPTION
getline() will return -1 when fail, so make the return value handle
correct.

Signed-off-by: Yunfeng Ye <yeyunfeng@huawei.com>