### PR TITLE
make the parameter line of getline be freeed correctly

### DIFF
--- a/cputree.c
+++ b/cputree.c
@@ -278,13 +278,13 @@ static void do_one_cpu(char *path)
 	if (file) {
 		char *line = NULL;
 		size_t size = 0;
-		if (getline(&line, &size, file)<=0)
-			return;
-		fclose(file);
-		if (line && line[0]=='0') {
+		if ((getline(&line, &size, file) <= 0) ||
+			(line && line[0] == '0')) {
+			fclose(file);
 			free(line);
 			return;
 		}
+		fclose(file);
 		free(line);
 	}
 


### PR DESCRIPTION
1 When getline ERRORNO is ENOMEM, the input line will return null. we can't free line when it's null.
2 This buffer should be freed by the user program even if getline() failed.
3 Threre exists file op with no closing before return.