### PR TITLE
free the memory when getline() fail in add_one_node()

### DIFF
--- a/numa.c
+++ b/numa.c
@@ -74,12 +74,11 @@ static void add_one_node(const char *nodename)
 		cpus_clear(new->mask);
 	} else {
 		ret = getline(&cpustr, &blen, f);
-		if (ret <= 0) {
+		if (ret <= 0)
 			cpus_clear(new->mask);
-		} else {
+		else
 			cpumask_parse_user(cpustr, ret, new->mask);
-			free(cpustr);
-		}
+		free(cpustr);
 	}
 	fclose(f);
 	new->obj_type = OBJ_TYPE_NODE;	


### PR DESCRIPTION
when getline() fail, the memory still need to be freed.

Signed-off-by: Yunfeng Ye <yeyunfeng@huawei.com>