### PR TITLE
prevent NULL pointer dereference when memory allocation failure

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -583,6 +583,7 @@ static void get_irq_user_policy(char *path, int irq, struct user_irq_policy *pol
 					break;
 				}
 			}
+			closedir(poldir);
 		}
 	}
 }

--- a/cputree.c
+++ b/cputree.c
@@ -432,6 +432,8 @@ static void dump_irq(struct irq_info *info, void *data)
 	int i;
 	char * indent = malloc (sizeof(char) * (spaces + 1));
 
+	if (!indent)
+		return;
 	for ( i = 0; i < spaces; i++ )
 		indent[i] = log_indent[0];
 

--- a/ui/irqbalance-ui.c
+++ b/ui/irqbalance-ui.c
@@ -424,6 +424,7 @@ int main(int argc, char **argv)
 					fclose(f);
 				}
 			} while((entry) && (irqbalance_pid == -1));
+			closedir(dir);
 		}
 		if(irqbalance_pid == -1) {
 			printf("Unable to determine irqbalance PID\n");


### PR DESCRIPTION
There are several places where memory allocation does not check return
values, adding null pointer checks.

Signed-off-by: Yunfeng Ye <yeyunfeng@huawei.com>