### PR TITLE
reduce redundant code for file processing

### DIFF
--- a/activate.c
+++ b/activate.c
@@ -36,22 +36,10 @@ static int check_affinity(struct irq_info *info, cpumask_t applied_mask)
 {
 	cpumask_t current_mask;
 	char buf[PATH_MAX];
-	char *line = NULL;
-	size_t size = 0;
-	FILE *file;
 
 	sprintf(buf, "/proc/irq/%i/smp_affinity", info->irq);
-	file = fopen(buf, "r");
-	if (!file)
+	if (process_one_line(buf, get_mask_from_bitmap, &current_mask) < 0)
 		return 1;
-	if (getline(&line, &size, file)<=0) {
-		free(line);
-		fclose(file);
-		return 1;
-	}
-	cpumask_parse_user(line, strlen(line), current_mask);
-	fclose(file);
-	free(line);
 
 	return cpus_equal(applied_mask, current_mask);
 }

--- a/classify.c
+++ b/classify.c
@@ -350,10 +350,7 @@ static struct irq_info *add_one_irq_to_db(const char *devpath, struct irq_info *
 	int numa_node;
 	char path[PATH_MAX];
 	FILE *fd;
-	char *lcpu_mask;
 	GList *entry;
-	ssize_t ret;
-	size_t blen;
 
 	/*
 	 * First check to make sure this isn't a duplicate entry
@@ -409,23 +406,11 @@ get_numa_node:
 	else
 		new->numa_node = get_numa_node(numa_node);
 
-	sprintf(path, "%s/local_cpus", devpath);
-	fd = fopen(path, "r");
-	if (!fd) {
-		cpus_setall(new->cpumask);
-		goto out;
-	}
-	lcpu_mask = NULL;
-	ret = getline(&lcpu_mask, &blen, fd);
-	fclose(fd);
-	if (ret <= 0) {
-		cpus_setall(new->cpumask);
-	} else {
-		cpumask_parse_user(lcpu_mask, ret, new->cpumask);
-	}
-	free(lcpu_mask);
+	cpus_setall(new->cpumask);
 
-out:
+	sprintf(path, "%s/local_cpus", devpath);
+	process_one_line(path, get_mask_from_bitmap, &new->cpumask);
+
 	log(TO_CONSOLE, LOG_INFO, "Adding IRQ %d to database\n", irq);
 	return new;
 }

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -160,5 +160,8 @@ extern unsigned int log_mask;
 #define SOCKET_PATH "irqbalance"
 #define SOCKET_TMPFS "/run/irqbalance/"
 
+extern int process_one_line(char *path, void (*cb)(char *line, void *data), void *data);
+extern void get_mask_from_bitmap(char *line, void *mask);
+
 #endif /* __INCLUDE_GUARD_IRQBALANCE_H_ */
 

--- a/numa.c
+++ b/numa.c
@@ -56,31 +56,15 @@ static void add_one_node(const char *nodename)
 {
 	char path[PATH_MAX];
 	struct topo_obj *new;
-	char *cpustr = NULL;
-	FILE *f;
-	ssize_t ret;
-	size_t blen;
 
 	new = calloc(1, sizeof(struct topo_obj));
 	if (!new)
 		return;
+
+	cpus_clear(new->mask);
 	sprintf(path, "%s/%s/cpumap", SYSFS_NODE_PATH, nodename);
-	f = fopen(path, "r");
-	if (!f) {
-		free(new);
-		return;
-	}
-	if (ferror(f)) {
-		cpus_clear(new->mask);
-	} else {
-		ret = getline(&cpustr, &blen, f);
-		if (ret <= 0)
-			cpus_clear(new->mask);
-		else
-			cpumask_parse_user(cpustr, ret, new->mask);
-		free(cpustr);
-	}
-	fclose(f);
+	process_one_line(path, get_mask_from_bitmap, &new->mask);
+
 	new->obj_type = OBJ_TYPE_NODE;	
 	new->number = strtoul(&nodename[4], NULL, 10);
 	new->obj_type_list = &numa_nodes;


### PR DESCRIPTION
There are some redundant codes about file processing which with the same
logic. so abstract the same logic to the one function, and invoke it
where it need.

A different is that in add_one_node(), not return if fopen() fail, and
remove the ferror() judgement, I think it has no effect.

Signed-off-by: Yunfeng Ye <yeyunfeng@huawei.com>