### PR TITLE
fix the problem of banmod that memory is freed before using

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -750,6 +750,13 @@ static void add_missing_irq(struct irq_info *info, void *attr)
 		add_new_irq(info->irq, info, proc_interrupts);
 }
 
+static void free_tmp_irqs(gpointer data)
+{
+	struct irq_info *info = data;
+
+	free(info->name);
+	free(info);
+}
 
 void rebuild_irq_db(void)
 {
@@ -779,7 +786,7 @@ void rebuild_irq_db(void)
 
 	for_each_irq(tmp_irqs, add_missing_irq, interrupts_db);
 
-	g_list_free_full(tmp_irqs, free);
+	g_list_free_full(tmp_irqs, free_tmp_irqs);
 
 }
 

--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -229,7 +229,7 @@ GList* collect_full_irq_list()
 				info->class = IRQ_OTHER;
 #endif
 			}
-			info->name = strdupa(irq_mod);
+			info->name = strdup(irq_mod);
 			tmp_list = g_list_append(tmp_list, info);
 		}
 		free(savedline);


### PR DESCRIPTION
Currently strdupa() is used to allocate memory for irq_info's name in
collect_full_irq_list(), we know that it allocate memory from stack,
when the invoking function return, the memory will be freed. so if the
irq_info's name is invalid, it will lead to check_for_module_ban() no
correct.

  check_for_irq_ban
    check_for_module_ban(res->name) // res->name is not valid

Use strdup() instead of strdupa(), and free the memory of irq_info's
name before freeing the irq_info.

Signed-off-by: Yunfeng Ye <yeyunfeng@huawei.com>