### PR TITLE
remove "c++;" in parse_proc_interrupts

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -212,7 +212,6 @@ GList* collect_full_irq_list()
 		irq_mod = last_token;
 
 		*c = 0;
-		c++;
 		number = strtoul(line, NULL, 10);
 
 		info = calloc(sizeof(struct irq_info), 1);


### PR DESCRIPTION
in parse_proc_interrupts, just get irq's name. After "*c = 0", characters after ":" in line and c are useless. There is no need to let c increase.