### PR TITLE
irqbalance: use isdigit() instead of the logic of character judgment

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -182,7 +182,7 @@ GList* collect_full_irq_list()
 		while (isblank(*(c)))
 			c++;
 
-		if (!(*c>='0' && *c<='9'))
+		if (!isdigit(*c))
 			break;
 		c = strchr(line, ':');
 		if (!c)
@@ -274,7 +274,7 @@ void parse_proc_interrupts(void)
 		while (isblank(*(c)))
 			c++;
 			
-		if (!(*c>='0' && *c<='9'))
+		if (!isdigit(*c))
 			break;
 		c = strchr(line, ':');
 		if (!c)


### PR DESCRIPTION
Signed-off-by: Yunfeng Ye <yeyunfeng@huawei.com>