### PR TITLE
some clean codes about cputree for irqbalance

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -275,7 +275,7 @@ static void add_banned_irq(int irq, GList **list)
 	if (entry)
 		return;
 
-	new = calloc(sizeof(struct irq_info), 1);
+	new = calloc(1, sizeof(struct irq_info));
 	if (!new) {
 		log(TO_CONSOLE, LOG_WARNING, "No memory to ban irq %d\n", irq);
 		return;
@@ -366,7 +366,7 @@ static struct irq_info *add_one_irq_to_db(const char *devpath, struct irq_info *
 		return NULL;
 	}
 
-	new = calloc(sizeof(struct irq_info), 1);
+	new = calloc(1, sizeof(struct irq_info));
 	if (!new)
 		return NULL;
 

--- a/cputree.c
+++ b/cputree.c
@@ -136,33 +136,17 @@ static void add_numa_node_to_topo_obj(struct topo_obj *obj, int nodeid)
 {
 	GList *entry;
 	struct topo_obj *node;
-	struct topo_obj *cand_node;
-	struct topo_obj *package;
 
 	node = get_numa_node(nodeid);
 	if (!node || (numa_avail && (node->number == -1)))
 		return;
 
-	entry = g_list_first(obj->numa_nodes);
-	while (entry) {
-		cand_node = entry->data;
-		if (cand_node == node)
-			break;
-		entry = g_list_next(entry);
-	}
-
+	entry = g_list_find(obj->numa_nodes, node);
 	if (!entry)
 		obj->numa_nodes = g_list_append(obj->numa_nodes, node);
 
 	if (!numa_avail && obj->obj_type == OBJ_TYPE_PACKAGE) {
-		entry = g_list_first(node->children);
-		while (entry) {
-			package = entry->data;
-			if (package == obj)
-				break;
-			entry = g_list_next(entry);
-		}
-
+		entry = g_list_find(node->children, obj);
 		if (!entry) {
 			node->children = g_list_append(node->children, obj);
 			obj->parent = node;
@@ -177,7 +161,6 @@ static struct topo_obj* add_cache_domain_to_package(struct topo_obj *cache,
 {
 	GList *entry;
 	struct topo_obj *package;
-	struct topo_obj *lcache; 
 
 	entry = g_list_first(packages);
 
@@ -202,14 +185,7 @@ static struct topo_obj* add_cache_domain_to_package(struct topo_obj *cache,
 		packages = g_list_append(packages, package);
 	}
 
-	entry = g_list_first(package->children);
-	while (entry) {
-		lcache = entry->data;
-		if (lcache == cache)
-			break;
-		entry = g_list_next(entry);
-	}
-
+	entry = g_list_find(package->children, cache);
 	if (!entry) {
 		package->children = g_list_append(package->children, cache);
 		cache->parent = package;
@@ -226,7 +202,6 @@ static struct topo_obj* add_cpu_to_cache_domain(struct topo_obj *cpu,
 {
 	GList *entry;
 	struct topo_obj *cache;
-	struct topo_obj *lcpu;
 
 	entry = g_list_first(cache_domains);
 
@@ -249,14 +224,7 @@ static struct topo_obj* add_cpu_to_cache_domain(struct topo_obj *cpu,
 		cache_domain_count++;
 	}
 
-	entry = g_list_first(cache->children);
-	while (entry) {
-		lcpu = entry->data;
-		if (lcpu == cpu)
-			break;
-		entry = g_list_next(entry);
-	}
-
+	entry = g_list_find(cache->children, cpu);
 	if (!entry) {
 		cache->children = g_list_append(cache->children, cpu);
 		cpu->parent = (struct topo_obj *)cache;

--- a/cputree.c
+++ b/cputree.c
@@ -44,7 +44,6 @@ GList *cpus;
 GList *cache_domains;
 GList *packages;
 
-int package_count;
 int cache_domain_count;
 int core_count;
 
@@ -201,7 +200,6 @@ static struct topo_obj* add_cache_domain_to_package(struct topo_obj *cache,
 		package->obj_type_list = &packages;
 		package->number = packageid;
 		packages = g_list_append(packages, package);
-		package_count++;
 	}
 
 	entry = g_list_first(package->children);
@@ -558,7 +556,6 @@ void clear_cpu_tree(void)
 {
 	g_list_free_full(packages, free_cpu_topo);
 	packages = NULL;
-	package_count = 0;
 
 	g_list_free_full(cache_domains, free_cpu_topo);
 	cache_domains = NULL;

--- a/cputree.c
+++ b/cputree.c
@@ -192,7 +192,7 @@ static struct topo_obj* add_cache_domain_to_package(struct topo_obj *cache,
 	}
 
 	if (!entry) {
-		package = calloc(sizeof(struct topo_obj), 1);
+		package = calloc(1, sizeof(struct topo_obj));
 		if (!package)
 			return NULL;
 		package->mask = package_mask;
@@ -238,7 +238,7 @@ static struct topo_obj* add_cpu_to_cache_domain(struct topo_obj *cpu,
 	}
 
 	if (!entry) {
-		cache = calloc(sizeof(struct topo_obj), 1);
+		cache = calloc(1, sizeof(struct topo_obj));
 		if (!cache)
 			return NULL;
 		cache->obj_type = OBJ_TYPE_CACHE;
@@ -302,7 +302,7 @@ static void do_one_cpu(char *path)
 	if (offline_status)
 		return;
 
-	cpu = calloc(sizeof(struct topo_obj), 1);
+	cpu = calloc(1, sizeof(struct topo_obj));
 	if (!cpu)
 		return;
 

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -29,8 +29,6 @@
 #include <systemd/sd-journal.h>
 #endif
 
-extern int package_count;
-extern int cache_domain_count;
 extern int core_count;
 extern char *classes[];
 

--- a/numa.c
+++ b/numa.c
@@ -136,7 +136,6 @@ void connect_cpu_mem_topo(struct topo_obj *p, void *data __attribute__((unused))
 {
 	GList *entry;
 	struct topo_obj *node;
-	struct topo_obj *lchild;
 	int len;
 
 	len = g_list_length(p->numa_nodes);
@@ -154,14 +153,7 @@ void connect_cpu_mem_topo(struct topo_obj *p, void *data __attribute__((unused))
 	if (p->obj_type == OBJ_TYPE_PACKAGE && !p->parent)
 		p->parent = node;
 
-	entry = g_list_first(node->children);
-	while (entry) {
-		lchild = entry->data;
-		if (lchild == p)
-			break;
-		entry = g_list_next(entry);
-	}
-
+	entry = g_list_find(node->children, p);
 	if (!entry)
 		node->children = g_list_append(node->children, p);
 }

--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -214,7 +214,7 @@ GList* collect_full_irq_list()
 		*c = 0;
 		number = strtoul(line, NULL, 10);
 
-		info = calloc(sizeof(struct irq_info), 1);
+		info = calloc(1, sizeof(struct irq_info));
 		if (info) {
 			info->irq = number;
 			if (strstr(irq_name, "-event") != NULL && is_xen_dyn == 1) {


### PR DESCRIPTION
remove unused package_count variable
modify the order of input parameter for calloc()
use g_list_find() instead of the search logic for cpu_topo 