### PR TITLE
irqbalance: use add_one_node() to create unspecified node for numa

### DIFF
--- a/cputree.c
+++ b/cputree.c
@@ -508,7 +508,7 @@ void parse_cpu_tree(void)
 
 }
 
-static void free_cpu_topo(gpointer data)
+void free_cpu_topo(gpointer data)
 {
 	struct topo_obj *obj = data;
 

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -51,6 +51,7 @@ void dump_tree(void);
 
 void activate_mappings(void);
 void clear_cpu_tree(void);
+void free_cpu_topo(gpointer data);
 
 /*===================NEW BALANCER FUNCTIONS============================*/
 


### PR DESCRIPTION
Use add_one_node(NUMA_NO_NODE) to create a unspecified node instead of
global variable.

It can reuse the function add_one_node() and delete two global variable
unspecified_node_template and unspecified_node. Also it can reuse the
function free_cpu_topo() instead of free_numa_node().

Signed-off-by: Yunfeng Ye <yeyunfeng@huawei.com>