### PR TITLE
use process_one_line() instead of fscanf() and remove redundancy check in add_one_irq_to_db()

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -285,17 +285,6 @@ void add_cl_banned_irq(int irq)
 	add_banned_irq(irq, &cl_banned_irqs);
 }
 
-static int is_banned_irq(int irq)
-{
-	GList *entry;
-	struct irq_info find;
-
-	find.irq = irq;
-
-	entry = g_list_find_custom(banned_irqs, &find, compare_ints);
-	return entry ? 1:0;
-}
-
 gint substr_find(gconstpointer a, gconstpointer b)
 {
 	if (strstr(b, a))
@@ -340,21 +329,6 @@ static struct irq_info *add_one_irq_to_db(const char *devpath, struct irq_info *
 	struct irq_info *new;
 	int numa_node;
 	char path[PATH_MAX];
-	GList *entry;
-
-	/*
-	 * First check to make sure this isn't a duplicate entry
-	 */
-	entry = g_list_find_custom(interrupts_db, hint, compare_ints);
-	if (entry) {
-		log(TO_CONSOLE, LOG_INFO, "DROPPING DUPLICATE ENTRY FOR IRQ %d on path %s\n", irq, devpath);
-		return NULL;
-	}
-
-	if (is_banned_irq(irq)) {
-		log(TO_ALL, LOG_INFO, "SKIPPING BANNED IRQ %d\n", irq);
-		return NULL;
-	}
 
 	new = calloc(1, sizeof(struct irq_info));
 	if (!new)

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -163,6 +163,8 @@ extern unsigned int log_mask;
 
 extern int process_one_line(char *path, void (*cb)(char *line, void *data), void *data);
 extern void get_mask_from_bitmap(char *line, void *mask);
+extern void get_int(char *line, void *data);
+extern void get_hex(char *line, void *data);
 
 #endif /* __INCLUDE_GUARD_IRQBALANCE_H_ */
 


### PR DESCRIPTION
irqbalance: use process_one_line() instead of fscanf()
irqbalance: remove redundancy check in add_one_irq_to_db()