### PR TITLE
improve irq migrating rule to avoid high cpu irq load

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -67,6 +67,7 @@ GMainLoop *main_loop;
 
 char *cpu_ban_string = NULL;
 char *banned_cpumask_from_ui = NULL;
+unsigned long migrate_ratio = 0;
 
 static void sleep_approx(int seconds)
 {
@@ -96,6 +97,7 @@ struct option lopts[] = {
 	{"banmod", 1 , NULL, 'm'},
 	{"interval", 1 , NULL, 't'},
 	{"version", 0, NULL, 'V'},
+	{"migrateval", 1, NULL, 'e'},
 	{0, 0, 0, 0}
 };
 
@@ -103,7 +105,7 @@ static void usage(void)
 {
 	log(TO_CONSOLE, LOG_INFO, "irqbalance [--oneshot | -o] [--debug | -d] [--foreground | -f] [--journal | -j]\n");
 	log(TO_CONSOLE, LOG_INFO, "	[--powerthresh= | -p <off> | <n>] [--banirq= | -i <n>] [--banmod= | -m <module>] [--policyscript= | -l <script>]\n");
-	log(TO_CONSOLE, LOG_INFO, "	[--pid= | -s <file>] [--deepestcache= | -c <n>] [--interval= | -t <n>]\n");
+	log(TO_CONSOLE, LOG_INFO, "	[--pid= | -s <file>] [--deepestcache= | -c <n>] [--interval= | -t <n>] [--migrateval= | -e <n>]\n");
 }
 
 static void version(void)
@@ -118,7 +120,7 @@ static void parse_command_line(int argc, char **argv)
 	unsigned long val;
 
 	while ((opt = getopt_long(argc, argv,
-		"odfjVi:p:s:c:l:m:t:",
+		"odfjVi:p:s:c:l:m:t:e:",
 		lopts, &longind)) != -1) {
 
 		switch(opt) {
@@ -186,6 +188,9 @@ static void parse_command_line(int argc, char **argv)
 					usage();
 					exit(1);
 				}
+				break;
+			case 'e':
+				migrate_ratio = strtoul(optarg, NULL, 10);
 				break;
 		}
 	}

--- a/irqbalance.c
+++ b/irqbalance.c
@@ -118,7 +118,7 @@ static void parse_command_line(int argc, char **argv)
 	unsigned long val;
 
 	while ((opt = getopt_long(argc, argv,
-		"odfji:p:s:c:l:m:t:V",
+		"odfjVi:p:s:c:l:m:t:",
 		lopts, &longind)) != -1) {
 
 		switch(opt) {

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -77,6 +77,7 @@ extern char *polscript;
 extern cpumask_t banned_cpus;
 extern cpumask_t unbanned_cpus;
 extern long HZ;
+extern unsigned long migrate_ratio;
 
 /*
  * Numa node access routines


### PR DESCRIPTION
The current irq migrating rule can't migrate irqs in some scenes,  which can lead one cpu irq load closer to 100%. For example:
        CPU0   CPU1  CPU2
irq0  50%     0%      0%
irq1  50%     0%      0%
irq3   0%      10%     0%
irq4   0%      0%       5%
total  100%  10%     5%
In the above scenes, the CPU0's irq load is too high, however the other cpus'   irq load is  very low.

By the old irq migrate rule, the irqs cannot be moved if the adjustment_load will become smaller than
the min_load after moving irq. However, we can accept that the delta load become smaller after moving irq. With the new migrating rule(migrate_ratio=2), the above cpu irq load can become much lower:
        CPU0   CPU1  CPU2
irq0  50%    0%      0%
irq1  0%      0%      50%
irq3   0%    10%     0%
irq4   0%     0%      5%
total  50%  10%     55%