### PR TITLE
free cpu_ban_string when the next request come

### DIFF
--- a/cputree.c
+++ b/cputree.c
@@ -118,10 +118,6 @@ static void setup_banned_cpus(void)
 	if (cpu_ban_string != NULL && banned_cpumask_from_ui != NULL) {
 		cpulist_parse(banned_cpumask_from_ui,
 			strlen(banned_cpumask_from_ui), banned_cpus);
-		/* release it safety, it was allocated in sock_handle */
-		free(cpu_ban_string);
-		cpu_ban_string = NULL;
-		banned_cpumask_from_ui = NULL;
 		goto out;
 	}
 	if (getenv("IRQBALANCE_BANNED_CPUS"))  {

--- a/irqbalance.c
+++ b/irqbalance.c
@@ -471,12 +471,9 @@ gboolean sock_handle(gint fd, GIOCondition condition, gpointer user_data __attri
 				free(irq_string);
 			} else if (!(strncmp(buff + strlen("settings "), "cpus ",
 							strlen("cpus")))) {
-				/*
-				 * if cpu_ban_string has not been consumed,
-				 * just ignore this request.
-				 */
-				if (cpu_ban_string != NULL)
-					goto out_close;
+				banned_cpumask_from_ui = NULL;
+				free(cpu_ban_string);
+				cpu_ban_string = NULL;
 
 				cpu_ban_string = malloc(
 						sizeof(char) * (recv_size - strlen("settings cpus ")));
@@ -489,15 +486,9 @@ gboolean sock_handle(gint fd, GIOCondition condition, gpointer user_data __attri
 				if (!strncmp(banned_cpumask_from_ui, "NULL", strlen("NULL"))) {
 					banned_cpumask_from_ui = NULL;
 					free(cpu_ban_string);
-					cpu_ban_string = NULL;;
-				} else {
-					/*
-					 * don't free cpu_ban_string at here, it will be
-					 * released after we have store it to @banned_cpus
-					 * in setup_banned_cpus function.
-					 */
-					need_rescan = 1;
+					cpu_ban_string = NULL;
 				}
+				need_rescan = 1;
 			}
 		}
 		if (!strncmp(buff, "setup", strlen("setup"))) {


### PR DESCRIPTION
if we free cpu_ban_string in setup_banned_cpus, when the next time we enter setup_banned_cpus by other causes, banned_cpus will be overrided by getenv("IRQBALANCE_BANNED_CPUS") or nohz_full | isolated_cpus. So we free cpu_ban_string when the next request come, keep banned cpus in cpu_ban_string  and banned_cpumask_from_ui, and parse banned_cpumask_from_ui it every time we enter setup_banned_cpus.
When we send "settings cpus NULL", we also need to set need_rescan to 1, otherwise we cannot enter setup_banned_cpus to override banned_cpus and it will keep the old value.