### PR TITLE
arm64: Add irq aff change check

### DIFF
--- a/activate.c
+++ b/activate.c
@@ -48,6 +48,7 @@ static void activate_mapping(struct irq_info *info, void *data __attribute__((un
 {
 	char buf[PATH_MAX];
 	FILE *file;
+	int ret = 0;
 
 	/*
  	 * only activate mappings for irqs that have moved
@@ -70,7 +71,12 @@ static void activate_mapping(struct irq_info *info, void *data __attribute__((un
 		return;
 
 	cpumask_scnprintf(buf, PATH_MAX, info->assigned_obj->mask);
-	fprintf(file, "%s", buf);
+	ret = fprintf(file, "%s", buf);
+	if (ret < 0) {
+		log(TO_ALL, LOG_WARNING, "cannot change irq %i's affinity, add it to banned list", info->irq);
+		add_banned_irq(info->irq);
+		remove_one_irq_from_db(info->irq);
+	}
 	fclose(file);
 	info->moved = 0; /*migration is done*/
 }

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -106,6 +106,8 @@ extern struct irq_info *get_irq_info(int irq);
 extern void migrate_irq(GList **from, GList **to, struct irq_info *info);
 extern void free_cl_opts(void);
 extern void add_cl_banned_module(char *modname);
+extern void add_banned_irq(int irq);
+extern void remove_one_irq_from_db(int irq);
 #define irq_numa_node(irq) ((irq)->numa_node)
 
 


### PR DESCRIPTION
For aarch64, the PPIs format in /proc/interrputs can be parsed and add to interrupt db, and next, the number of interrupts is counted and used to calculate the load. Finally these interrupts maybe scheduled between the NUMA domains.

Acctually, the PPIs cannot change aff, and it should not be added to interrupt db. This patch fix it.

Add a check before add a interrupt to db, just only reads the irq's aff, and write it back to avoid any impact on the system, According to the result of writing to fitler the irq.