### PR TITLE
remove redundant "/" in SOCKET_TMPFS

### DIFF
--- a/irqbalance.h
+++ b/irqbalance.h
@@ -162,7 +162,7 @@ extern unsigned int log_mask;
 #endif /* HAVE_LIBSYSTEMD */
 
 #define SOCKET_PATH "irqbalance"
-#define SOCKET_TMPFS "/run/irqbalance/"
+#define SOCKET_TMPFS "/run/irqbalance"
 
 extern int process_one_line(char *path, void (*cb)(char *line, void *data), void *data);
 extern void get_mask_from_bitmap(char *line, void *mask);


### PR DESCRIPTION
SOCKET_TMPFS is defined as "/run/irqbalance/", which is used in irqbalance.c init_socket():
- snprintf(socket_name, 64, "%s/%s%d.sock", SOCKET_TMPFS, SOCKET_PATH, getpid());
so the third "/" in SOCKET_TMPFS is redundant.
it won't cause any bug, i just think it would be better to keep same as SOCKET_TMPFS defined in ui/irqbalance-ui.h