### PR TITLE
put arg parsing detail into parse_command_line()

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -195,7 +195,23 @@ static void parse_command_line(int argc, char **argv)
 		}
 	}
 }
-#endif
+#else /* ! HAVE_GETOPT_LONG */
+static void parse_command_line(int argc, char **argv)
+{
+	if (argc>1 && strstr(argv[1],"--debug")) {
+		debug_mode=1;
+		foreground_mode=1;
+	}
+	if (argc>1 && strstr(argv[1],"--foreground"))
+		foreground_mode=1;
+	if (argc>1 && strstr(argv[1],"--oneshot"))
+		one_shot_mode=1;
+	if (argc>1 && strstr(argv[1],"--journal")) {
+		journal_logging=1;
+		foreground_mode=1;
+	}
+}
+#endif /* HAVE_GETOPT_LONG */
 
 /*
  * This builds our object tree.  The Hierarchy is typically pretty
@@ -581,22 +597,8 @@ int main(int argc, char** argv)
 	sigaddset(&sigset,SIGUSR1);
 	sigaddset(&sigset,SIGUSR2);
 	sigprocmask(SIG_BLOCK, &sigset, &old_sigset);
-#ifdef HAVE_GETOPT_LONG
+
 	parse_command_line(argc, argv);
-#else /* ! HAVE_GETOPT_LONG */
-	if (argc>1 && strstr(argv[1],"--debug")) {
-		debug_mode=1;
-		foreground_mode=1;
-	}
-	if (argc>1 && strstr(argv[1],"--foreground"))
-		foreground_mode=1;
-	if (argc>1 && strstr(argv[1],"--oneshot"))
-		one_shot_mode=1;
-	if (argc>1 && strstr(argv[1],"--journal")) {
-		journal_logging=1;
-		foreground_mode=1;
-	}
-#endif /* HAVE_GETOPT_LONG */
 
 	/*
  	 * Open the syslog connection


### PR DESCRIPTION
Currently parse_command_line() implements the arg parsing function,
but if HAVE_GETOPT_LONG is not defined, the arg parsing detail is
in main() funtion.

So put the arg parsing detail into parse_command_line() is more
clearly.