### PR TITLE
add env variable to ban cpus using cpulist syntax

### DIFF
--- a/cputree.c
+++ b/cputree.c
@@ -127,6 +127,12 @@ static void setup_banned_cpus(void)
 		goto out;
 	}
 
+	env = getenv("IRQBALANCE_BANNED_CPULIST");
+	if (env && strlen(env)) {
+		cpulist_parse(env, strlen(env), banned_cpus);
+		goto out;
+	}
+
 	path = "/sys/devices/system/cpu/isolated";
 	process_one_line(path, get_mask_from_cpulist, &isolated_cpus);
 

--- a/irqbalance.1
+++ b/irqbalance.1
@@ -158,6 +158,12 @@ Provides a mask of CPUs which irqbalance should ignore and never assign interrup
 If not specified, irqbalance use mask of isolated and adaptive-ticks CPUs on the
 system as the default value.
 
+.TP
+.B IRQBALANCE_BANNED_CPULIST
+Provides a cpulist which irqbalance should ignore and never assign interrupts to.
+If not specified, irqbalance use mask of isolated and adaptive-ticks CPUs on the
+system as the default value.
+
 .SH "SIGNALS"
 .TP
 .B SIGHUP


### PR DESCRIPTION
allows banning of cpus using the taskset cpulist syntax in addition to the
bitmap syntax supported via the existing environment variable
IRQBALANCE_BANNED_CPUS