### PR TITLE
Add irq hotplug feature for irqbalance

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -249,7 +249,7 @@ static void dump_object_tree(void)
 	for_each_object(numa_nodes, dump_numa_node_info, NULL);
 }
 
-static void force_rebalance_irq(struct irq_info *info, void *data __attribute__((unused)))
+void force_rebalance_irq(struct irq_info *info, void *data __attribute__((unused)))
 {
 	if (info->level == BALANCE_NONE)
 		return;

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -40,8 +40,11 @@ extern GList* collect_full_irq_list();
 extern void parse_proc_stat(void);
 extern void set_interrupt_count(int number, uint64_t count);
 extern void set_msi_interrupt_numa(int number);
+extern void init_irq_class_and_type(char *savedline, struct irq_info *info, int irq);
+extern int proc_irq_hotplug(char *line, int irq, struct irq_info **pinfo);
 
 extern GList *rebalance_irq_list;
+extern void force_rebalance_irq(struct irq_info *info, void *data __attribute__((unused)));
 
 void update_migration_status(void);
 void dump_workloads(void);
@@ -52,7 +55,6 @@ void dump_tree(void);
 void activate_mappings(void);
 void clear_cpu_tree(void);
 void free_cpu_topo(gpointer data);
-
 /*===================NEW BALANCER FUNCTIONS============================*/
 
 /*


### PR DESCRIPTION
When new irqs added to the system, irqbalance will need to rescan for rebalancing.
The rescan operation exists the following problems:
1. When there existing many irqs to balance, the rescan operation will cost much time.
2. The rescan operation will produce irq migration with a high probability, which can make irq data cold, and affect the system performance.

To avoid the above problems, we provide the irq hotplug feature for irqbalance. 
When we find new irqs during reading "/proc/interrupts", then we add the new irqs to interrupts_db,
and place them in rebalance irq list. 

The irq hotplug feature for irqbalance can rebalance new irqs quickly without irq migration.We have used the irqbalance hotplug feature in our product for many years.It brings high performance to us when occuring irq hotplug.