### PR TITLE
Add irq hot pull method for irqbalance

### DIFF
--- a/irqbalance.h
+++ b/irqbalance.h
@@ -42,6 +42,7 @@ extern void set_interrupt_count(int number, uint64_t count);
 extern void set_msi_interrupt_numa(int number);
 extern void init_irq_class_and_type(char *savedline, struct irq_info *info, int irq);
 extern int proc_irq_hotplug(char *line, int irq, struct irq_info **pinfo);
+extern void clear_no_existing_irqs(void);
 
 extern GList *rebalance_irq_list;
 extern void force_rebalance_irq(struct irq_info *info, void *data __attribute__((unused)));

--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -248,7 +248,6 @@ GList* collect_full_irq_list()
 	return tmp_list;
 }
 
-
 void parse_proc_interrupts(void)
 {
 	FILE *file;
@@ -310,6 +309,7 @@ void parse_proc_interrupts(void)
 				break;
 			}
 		}
+		info->existing = 1;
 		free(savedline);
 
 		count = 0;
@@ -354,6 +354,8 @@ void parse_proc_interrupts(void)
  		 */
 		msi_found_in_sysfs = 1;
 	}
+	if (!need_rescan)
+		clear_no_existing_irqs();
 	fclose(file);
 	free(line);
 }

--- a/types.h
+++ b/types.h
@@ -70,6 +70,7 @@ struct irq_info {
 	uint64_t last_irq_count;
 	uint64_t load;
 	int moved;
+	int existing;
 	struct topo_obj *assigned_obj;
 	char *name;
 };


### PR DESCRIPTION
The pci devices can be hot pulled from the system, and the corresponding irqs will be  deactive. By add the irq hot pull method, we can manage irqs  more efficiently with less resource consumption.