### PR TITLE
Also fetch node info for non-PCI devices

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -361,9 +361,14 @@ static struct irq_info *add_one_irq_to_db(const char *devpath, struct irq_info *
 
 get_numa_node:
 	numa_node = NUMA_NO_NODE;
-	if (devpath != NULL && numa_avail) {
-		sprintf(path, "%s/numa_node", devpath);
-		process_one_line(path, get_int, &numa_node);
+	if (numa_avail) {
+		if (devpath != NULL) {
+			sprintf(path, "%s/numa_node", devpath);
+			process_one_line(path, get_int, &numa_node);
+		} else {
+			sprintf(path, "/proc/irq/%i/node", irq);
+			process_one_line(path, get_int, &numa_node);
+		}
 	}
 
 	if (pol->numa_node_set == 1)


### PR DESCRIPTION
Followring error is observed on some large servers:

[   40.345505] irq 4: Affinity broken due to vector space exhaustion.

Irq 4 is on node 0 but irqbalance put it in node 1. Root cause is that irq 4 is not an from an PCI device so irqbalance failed to get the right numa node number.

This PR fixes this problem.