### PR TITLE
fix uint64_t printf format (use PRIu64)

### DIFF
--- a/cputree.c
+++ b/cputree.c
@@ -33,6 +33,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include <inttypes.h>
 
 #include <glib.h>
 
@@ -417,7 +418,7 @@ static void dump_irq(struct irq_info *info, void *data)
 		indent[i] = log_indent[0];
 
 	indent[i] = '\0';
-	log(TO_CONSOLE, LOG_INFO, "%sInterrupt %i node_num is %d (%s/%lu:%lu) \n", indent,
+	log(TO_CONSOLE, LOG_INFO, "%sInterrupt %i node_num is %d (%s/%" PRIu64 ":%" PRIu64 ") \n", indent,
 	    info->irq, irq_numa_node(info)->number, classes[info->class], info->load, (info->irq_count - info->last_irq_count));
 	free(indent);
 }

--- a/irqbalance.c
+++ b/irqbalance.c
@@ -34,6 +34,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #ifdef HAVE_GETOPT_LONG 
 #include <getopt.h>
 #endif
@@ -357,7 +358,7 @@ void get_irq_data(struct irq_info *irq, void *data)
 	*irqdata = newptr;
 
 	sprintf(*irqdata + strlen(*irqdata),
-			"IRQ %d LOAD %lu DIFF %lu CLASS %d ", irq->irq, irq->load,
+			"IRQ %d LOAD %" PRIu64 " DIFF %" PRIu64 " CLASS %d ", irq->irq, irq->load,
 			(irq->irq_count - irq->last_irq_count), irq->class);
 }
 
@@ -395,7 +396,7 @@ void get_object_stat(struct topo_obj *object, void *data)
 
 	*stats = newptr;
 
-	sprintf(*stats + strlen(*stats), "TYPE %d NUMBER %d LOAD %lu SAVE_MODE %d %s",
+	sprintf(*stats + strlen(*stats), "TYPE %d NUMBER %d LOAD %" PRIu64 " SAVE_MODE %d %s",
 			object->obj_type, object->number, object->load,
 			object->powersave_mode, irq_data ? irq_data : "");
 	free(irq_data);

--- a/ui/ui.c
+++ b/ui/ui.c
@@ -1,4 +1,5 @@
 
+#include <inttypes.h>
 #include <string.h>
 #include "ui.h"
 
@@ -563,7 +564,7 @@ void settings()
 
 	char info[128] = "Current sleep interval between rebalancing: \0";
 	uint8_t sleep_input_offset = strlen(info) + 3;
-	snprintf(info + strlen(info), 128 - strlen(info), "%lu\n", setup.sleep);
+	snprintf(info + strlen(info), 128 - strlen(info), "%" PRIu64 "\n", setup.sleep);
 	attrset(COLOR_PAIR(1));
 	mvprintw(2, 3, info);
 	print_all_cpus();
@@ -588,7 +589,7 @@ void settings()
 			if(new_sleep != setup.sleep) {
 				setup.sleep = new_sleep;
 				char settings_data[128];
-				snprintf(settings_data, 128, "%s %lu", SET_SLEEP, new_sleep);
+				snprintf(settings_data, 128, "%s %" PRIu64, SET_SLEEP, new_sleep);
 				send_settings(settings_data);
 			}
 			break;


### PR DESCRIPTION
Fixes (on arm 32-bit):

  $ irqbalance-ui
  Invalid data sent.  Unexpected token: (null)TYPE

And strace showed the following:

  237   sendmsg(3, {msg_name=NULL, msg_namelen=0, msg_iov=[{iov_base="stats", iov_len=5}], msg_iovlen=1, msg_control=[{cmsg_len=24, cmsg_level=SOL_SOCKET, cmsg_type=SCM_CREDENTIALS, cmsg_data={pid=237, uid=0, gid=0}}], msg_controllen=24, msg_flags=0}, 0) = 5
  237   recv(3, "TYPE 3 NUMBER -1 LOAD 0 SAVE_MODE 0 (null)TYPE 2 NUMBER 0 LOAD 0 SAVE_MODE 0 (null)TYPE 1 NUMBER 0 LOAD 0 SAVE_MODE 0 (null)TYPE 0 NUMBER 3 LOAD 0 SAVE_MODE 0 (null)TYPE 1 NUMBER 1 LOAD 0 SAVE_MODE 0 (null)TYPE 0 NUMBER 1 LOAD 0 SAVE_MODE 0 (null)TYPE 1 NUMBER 2 LOAD 0 SAVE_MODE 0 (null)TYPE 0 NUMBER 2 LOAD 0 SAVE_MODE 0 (null)TYPE 1 NUMBER 3 LOAD 0 SAVE_MODE 0 (null)TYPE 0 NUMBER 0 LOAD 0 SAVE_MODE 0 (null)", 8192, 0) = 411

Signed-off-by: Peter Seiderer <ps.report@gmx.net>