### PR TITLE
ui: fix cpu/irq menu off by one

### DIFF
--- a/ui/ui.c
+++ b/ui/ui.c
@@ -231,7 +231,7 @@ void handle_cpu_banning()
 	move(6, 19);
 	curs_set(1);
 	refresh();
-	size_t position = 5;
+	size_t position = 6;
 	char processing = 1;
 	while(processing) {
 		int direction = getch();
@@ -433,7 +433,7 @@ void handle_irq_banning()
 	move(4, 19);
 	curs_set(1);
 	refresh();
-	size_t position = 3;
+	size_t position = 4;
 	char processing = 1;
 	while(processing) {
 		int direction = getch();


### PR DESCRIPTION
Fix start position for the SETTINGS/CPU ban menu.

Fixes (start irqbalance-ui, press F4, press c, press Enter):

  $ irqbalance-ui
  Segmentation fault (core dumped)

  $ gdb irqbalance-ui core
  Program terminated with signal SIGSEGV, Segmentation fault.
  #0  toggle_cpu (cpu_list=cpu_list@entry=0x90e170,
      cpu_number=cpu_number@entry=-1) at ui/ui.c:192
  192			entry_data = (cpu_ban_t *)(entry->data);
  (gdb) where
  #0  toggle_cpu (cpu_list=cpu_list@entry=0x90e170,
      cpu_number=cpu_number@entry=-1) at ui/ui.c:192
  #1  0x00013d4c in handle_cpu_banning () at ui/ui.c:254
  #2  0x0001371c in settings () at ui/ui.c:598
  #3  0x0001199c in key_loop (data=<optimized out>) at ui/irqbalance-ui.c:378
  #4  0xb6ed9ae8 in ?? ()

For the starting position '5' cpu_number is calculated as '-1'.

Fix the same off by one for the SETUP IRQS/IRQ banning menu.

Signed-off-by: Peter Seiderer <ps.report@gmx.net>