### PR TITLE
Add return value check of opendir in do_one_cpu

### DIFF
--- a/cputree.c
+++ b/cputree.c
@@ -366,21 +366,23 @@ static void do_one_cpu(char *path)
 		struct topo_obj *node;
 
 		dir = opendir(path);
-		do {
-			entry = readdir(dir);
-			if (!entry)
-				break;
-			if (strncmp(entry->d_name, "node", 4) == 0) {
-				char *end;
-				int num;
-				num = strtol(entry->d_name + 4, &end, 10);
-				if (!*end && num >= 0) {
-					nodeid = num;
+		if (dir) {
+			do {
+				entry = readdir(dir);
+				if (!entry)
 					break;
+				if (strncmp(entry->d_name, "node", 4) == 0) {
+					char *end;
+					int num;
+					num = strtol(entry->d_name + 4, &end, 10);
+					if (!*end && num >= 0) {
+						nodeid = num;
+						break;
+					}
 				}
-			}
-		} while (entry);
-		closedir(dir);
+			} while (entry);
+			closedir(dir);
+		}
 
 		/*
 		 * In case of multiple NUMA nodes within a CPU package,


### PR DESCRIPTION
The input para(path) of do_one_cpu is /sys/devices/system/cpu/cpu$id. When the cpus occur some error, /sys/devices/system/cpu/cpu$id will be diappear, and opendir(path) will return null. Thus, irqbalance will exit with coredump.