### PR TITLE
Add return value check of opendir in do_one_cpu

### DIFF
--- a/cputree.c
+++ b/cputree.c
@@ -366,7 +366,7 @@ static void do_one_cpu(char *path)
 		struct topo_obj *node;
 
 		dir = opendir(path);
-		do {
+		while (dir) {
 			entry = readdir(dir);
 			if (!entry)
 				break;
@@ -379,8 +379,9 @@ static void do_one_cpu(char *path)
 					break;
 				}
 			}
-		} while (entry);
-		closedir(dir);
+		}
+		if (dir)
+			closedir(dir);
 
 		/*
 		 * In case of multiple NUMA nodes within a CPU package,


### PR DESCRIPTION
The input para(path) of do_one_cpu is /sys/devices/system/cpu/cpu$id. When the cpus occur some error, /sys/devices/system/cpu/cpu$id will be diappear, and opendir(path) will return null. Thus, irqbalance will exit with coredump.