### PR TITLE
Fix compile issue with none AARCH64 builds

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -152,9 +152,9 @@ void init_irq_class_and_type(char *savedline, struct irq_info *info, int irq)
 	char *last_token = NULL;
 	char *p = NULL;
 	int is_xen_dyn = 0;
+	char irq_fullname[PATH_MAX] = {0};
 #ifdef AARCH64
 	char *tmp = NULL;
-	char irq_fullname[PATH_MAX] = {0};
 #endif
 
 	irq_name = strtok_r(savedline, " ", &savedptr);


### PR DESCRIPTION
This recent commit broke compiling on non AARCH64 architectures:
    commit d17bcc953c513f93553f531e5444553f2bf6ca46
    Author: liuchao173 <55137861+liuchao173@users.noreply.github.com>
    Date:   Tue Apr 27 15:36:30 2021 +0800
    Fix irqbalance cannot obtain the full name of irq

This results in:
    procinterrupts.c:186:11: error: ‘irq_fullname’ undeclared (first use in this function); did you mean ‘irq_name’?
      186 |  snprintf(irq_fullname, PATH_MAX, "%s", last_token);
	  |           ^~~~~~~~~~~~
	  |           irq_name
    procinterrupts.c:186:11: note: each undeclared identifier is reported only once for each function it appears in

This fixes it.

Signed-off-by: Michael Neuling <mikey@neuling.org>