### PR TITLE
Disable the communication socket when UI is disabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,10 +41,13 @@ AC_C_INLINE
 AM_PROG_CC_C_O
 
 AC_ARG_WITH([irqbalance-ui],
-	[AC_HELP_STRING([--without-irqbalance-ui],
-			[Dont build the irqbalance ui component])],
-			[with_irqbalanceui=$withval], [with_irqbalanceui=yes])
-
+  [AS_HELP_STRING([--without-irqbalance-ui],
+    [Dont build the irqbalance ui component])],
+    [with_irqbalanceui=$withval], [with_irqbalanceui=yes])
+AS_IF(
+  [test "x$with_irqbalanceui" = "xyes"], [
+    AC_DEFINE([HAVE_IRQBALANCEUI], 1, [Build irqbalance ui component.])
+])
 AM_CONDITIONAL([IRQBALANCEUI], [test x$with_irqbalanceui = xyes])
 
 AC_ARG_WITH([systemd],

--- a/cputree.c
+++ b/cputree.c
@@ -39,7 +39,9 @@
 
 #include "irqbalance.h"
 
+#ifdef HAVE_IRQBALANCEUI
 extern char *banned_cpumask_from_ui;
+#endif
 extern char *cpu_ban_string;
 
 GList *cpus;
@@ -113,12 +115,14 @@ static void setup_banned_cpus(void)
 	cpumask_t isolated_cpus;
 	char *env = NULL;
 
+#ifdef HAVE_IRQBALANCEUI
 	/* A manually specified cpumask overrides auto-detection. */
 	if (cpu_ban_string != NULL && banned_cpumask_from_ui != NULL) {
 		cpulist_parse(banned_cpumask_from_ui,
 			strlen(banned_cpumask_from_ui), banned_cpus);
 		goto out;
 	}
+#endif
 
 	/*
 	 * Notes:


### PR DESCRIPTION
Hi,

I think the UI is actually the only user of the socket right?

If the communication socket is added to support the UI, then when UI is not built, also disable the socket, save a bit of resource and improve security.

Or maybe a separate parameter like `--without-socket` is better?