### PR TITLE
configure.ac: use pkg-config to find numa

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,7 +27,7 @@ EXTRA_DIST = COPYING autogen.sh misc/irqbalance.service misc/irqbalance.env
 SUBDIRS = tests
 
 UI_DIR = ui
-AM_CFLAGS = $(LIBCAP_NG_CFLAGS) $(GLIB2_CFLAGS)
+AM_CFLAGS = $(LIBCAP_NG_CFLAGS) $(GLIB2_CFLAGS) $(NUMA_CFLAGS)
 AM_CPPFLAGS = -I${top_srcdir} -W -Wall -Wshadow -Wformat -Wundef -D_GNU_SOURCE
 noinst_HEADERS = bitmap.h constants.h cpumask.h irqbalance.h non-atomic.h \
 	types.h $(UI_DIR)/helpers.h $(UI_DIR)/irqbalance-ui.h $(UI_DIR)/ui.h
@@ -39,11 +39,11 @@ endif
 
 irqbalance_SOURCES = activate.c bitmap.c classify.c cputree.c irqbalance.c \
 	irqlist.c numa.c placement.c procinterrupts.c
-irqbalance_LDADD = $(LIBCAP_NG_LIBS) $(GLIB2_LIBS)
+irqbalance_LDADD = $(LIBCAP_NG_LIBS) $(GLIB2_LIBS) $(NUMA_LIBS)
 if IRQBALANCEUI
 irqbalance_ui_SOURCES = $(UI_DIR)/helpers.c $(UI_DIR)/irqbalance-ui.c \
 	$(UI_DIR)/ui.c
-irqbalance_ui_LDADD = $(GLIB2_LIBS) $(CURSES_LIBS)
+irqbalance_ui_LDADD = $(GLIB2_LIBS) $(NUMA_LIBS) $(CURSES_LIBS)
 endif
 
 dist_man_MANS = irqbalance.1

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_CHECK_HEADERS([numa.h])
 
 AC_CHECK_FUNCS(getopt_long)
 
-AC_CHECK_LIB(numa, numa_available)
+PKG_CHECK_MODULES([NUMA], [numa], [has_numa=yes], [AC_CHECK_LIB(numa, numa_available)])
 AC_CHECK_LIB(m, floor)
 
 PKG_CHECK_MODULES([GLIB2], [glib-2.0], [], [AC_MSG_ERROR([glib-2.0 is required])])


### PR DESCRIPTION
Use pkg-config to find numa and fallback to current mechanism. Thanks to pkg-config, numa dependencies such as `-latomic` will be retrieved.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>