### PR TITLE
irqbalance: Check validity of numa_node

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -376,6 +376,11 @@ get_numa_node:
 	else
 		new->numa_node = get_numa_node(numa_node);
 
+	if (!new->numa_node) {
+		log(TO_CONSOLE, LOG_WARNING, "IRQ %d has an unknown node\n", irq);
+		new->numa_node = get_numa_node(NUMA_NO_NODE);
+	}
+
 	cpus_setall(new->cpumask);
 	if (devpath != NULL) {
 		sprintf(path, "%s/local_cpus", devpath);


### PR DESCRIPTION
If Linux maps an IRQ associated with an empty node (hence not exposed
under /sys/devices/system/node/), irq_numa_node(info) will be set to
NULL, leading to a core dump in place_irq_in_node().

Add a warning for this unusual condition and set ->numa_node to the
the default entry.

Signed-off-by: Cédric Le Goater <clg@kaod.org>