### PR TITLE
fix opendir fails in check_platform_device

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -178,10 +178,12 @@ void init_irq_class_and_type(char *savedline, struct irq_info *info, int irq)
 	}
 
 #ifdef AARCH64
-	snprintf(irq_fullname, PATH_MAX, "%s %s", last_token, savedptr);
-	tmp = strchr(irq_fullname, '\n');
-	if (tmp)
-		*tmp = 0;
+	if (strlen(savedptr) > 0) {
+		snprintf(irq_fullname, PATH_MAX, "%s %s", last_token, savedptr);
+		tmp = strchr(irq_fullname, '\n');
+		if (tmp)
+			*tmp = 0;
+	}
 #else
 	snprintf(irq_fullname, PATH_MAX, "%s", last_token);
 #endif


### PR DESCRIPTION
When irq name does not contain spaces, savedptr is an empty string and irq_fullname will have a extra space at the end like "LNRO0005:00 ".
So opendir in check_platform_device will fail, and irqbalance prints log:
"No directory /sys/devices/platform/LNRO0005:00 /: No such file or directory"