### PR TITLE
Drop CapabilityBoundingSet from irqbalance service

### DIFF
--- a/misc/irqbalance.service
+++ b/misc/irqbalance.service
@@ -8,7 +8,6 @@ ConditionVirtualization=!container
 EnvironmentFile=-/usr/lib/irqbalance/defaults.env
 EnvironmentFile=-/path/to/irqbalance.env
 ExecStart=/usr/sbin/irqbalance --foreground $IRQBALANCE_ARGS
-CapabilityBoundingSet=
 ReadOnlyPaths=/
 ReadWritePaths=/proc/irq
 RestrictAddressFamilies=AF_UNIX


### PR DESCRIPTION
libcapng is issuing an error in the system log when irqbalance attempts
to drop capabilities, but systemd service unit has already done dropped
all capabilities. commit 43751df tried to fix this but it didn't fix it
completely. CapabilityBoundingSet also need to be dropped.

Fixes #182