### PR TITLE
ui/ui.c: always use "%s"-style format for printf()-style functions

### DIFF
--- a/ui/ui.c
+++ b/ui/ui.c
@@ -26,7 +26,7 @@ void show_frame()
 	while(strlen(top) != (size_t)COLS - 1) {
 		snprintf(top + strlen(top), COLS - strlen(top), " ");
 	}
-	mvprintw(0, 0, top);
+	mvprintw(0, 0, "%s", top);
 	for(i = 0; i < LINES; i++) {
 		mvprintw(i, 0, " ");
 		mvprintw(i, COLS - 1, " ");
@@ -42,7 +42,7 @@ void show_footer()
 		snprintf(footer + strlen(footer), COLS - strlen(footer), " ");
 	}
 	attrset(COLOR_PAIR(4));
-	mvprintw(LINES - 1, 0, footer);
+	mvprintw(LINES - 1, 0, "%s", footer);
 }
 
 char * check_control_in_sleep_input(int max_len, int column_offest, int line_offset)
@@ -331,7 +331,7 @@ void print_assigned_objects_string(irq_t *irq, int *line_offset)
 	char assigned_to[128] = "\0";
 	for_each_int(irq->assigned_to, copy_assigned_obj, assigned_to);
 	assigned_to[strlen(assigned_to) - 2] = '\0';
-	mvprintw(*line_offset, 36, assigned_to);
+	mvprintw(*line_offset, 36, "%s", assigned_to);
 }
 
 void print_irq_line(irq_t *irq, void *data)
@@ -566,7 +566,7 @@ void settings()
 	uint8_t sleep_input_offset = strlen(info) + 3;
 	snprintf(info + strlen(info), 128 - strlen(info), "%" PRIu64 "\n", setup.sleep);
 	attrset(COLOR_PAIR(1));
-	mvprintw(2, 3, info);
+	mvprintw(2, 3, "%s", info);
 	print_all_cpus();
 
 	int user_input = 1;
@@ -664,7 +664,7 @@ void display_tree_node_irqs(irq_t *irq, void *data)
 	char indent[32] = "	   \0";
 	snprintf(indent + strlen(indent), 32 - strlen(indent), "%s", (char *)data);
 	attrset(COLOR_PAIR(3));
-	printw("%sIRQ %lu, IRQs since last rebalance %lu\n",
+	printw("%sIRQ %u, IRQs since last rebalance %lu\n",
 			indent, irq->vector, irq->diff);
 }
 
@@ -711,7 +711,7 @@ void display_tree_node(cpu_node_t *node, void *data)
 	default:
 		break;
 	}
-	printw(copy_to);
+	printw("%s", copy_to);
 	if(g_list_length(node->irqs) > 0) {
 		for_each_irq(node->irqs, display_tree_node_irqs, indent);
 	}


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    ui/ui.c:714:16: error: format not a string literal and no format arguments [-Werror=format-security]
      714 |         printw(copy_to);
          |                ^~~~~~~

Let's wrap all the missing places with "%s" format.