### PR TITLE
 Add '\0' to the end of strings to avoid heap buffer overflow

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -463,12 +463,13 @@ gboolean sock_handle(gint fd, GIOCondition condition, gpointer user_data __attri
 			if (!(strncmp(buff + strlen("settings "), "sleep ",
 							strlen("sleep ")))) {
 				char *sleep_string = malloc(
-						sizeof(char) * (recv_size - strlen("settings sleep ")));
+						sizeof(char) * (recv_size - strlen("settings sleep ") + 1));
 
 				if (!sleep_string)
 					goto out_close;
 				strncpy(sleep_string, buff + strlen("settings sleep "),
 						recv_size - strlen("settings sleep "));
+				sleep_string[recv_size - strlen("settings sleep ")] = '\0';
 				int new_iterval = strtoul(sleep_string, NULL, 10);
 				if (new_iterval >= 1) {
 					sleep_interval = new_iterval;
@@ -478,12 +479,13 @@ gboolean sock_handle(gint fd, GIOCondition condition, gpointer user_data __attri
 							strlen("ban irqs ")))) {
 				char *end;
 				char *irq_string = malloc(
-						sizeof(char) * (recv_size - strlen("settings ban irqs ")));
+						sizeof(char) * (recv_size - strlen("settings ban irqs ") + 1));
 
 				if (!irq_string)
 					goto out_close;
 				strncpy(irq_string, buff + strlen("settings ban irqs "),
 						recv_size - strlen("settings ban irqs "));
+				irq_string[recv_size - strlen("settings ban irqs ")] = '\0';
 				g_list_free_full(cl_banned_irqs, free);
 				cl_banned_irqs = NULL;
 				need_rescan = 1;
@@ -503,12 +505,13 @@ gboolean sock_handle(gint fd, GIOCondition condition, gpointer user_data __attri
 				cpu_ban_string = NULL;
 
 				cpu_ban_string = malloc(
-						sizeof(char) * (recv_size - strlen("settings cpus ")));
+						sizeof(char) * (recv_size - strlen("settings cpus ") + 1));
 
 				if (!cpu_ban_string)
 					goto out_close;
 				strncpy(cpu_ban_string, buff + strlen("settings cpus "),
 						recv_size - strlen("settings cpus "));
+				cpu_ban_string[recv_size - strlen("settings cpus ")] = '\0';
 				banned_cpumask_from_ui = strtok(cpu_ban_string, " ");
 				if (!strncmp(banned_cpumask_from_ui, "NULL", strlen("NULL"))) {
 					banned_cpumask_from_ui = NULL;


### PR DESCRIPTION
Stroul, strlen, strtok will read or write out of bounds when recv_msg
doesn't include '\0'. Especially strtok will write '\0' when it find a
space, which may overwrite the head of the chunk in glibc, and
irqbalance will core dump.

core's stack:
(gdb) bt
 #0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
 #1  0x00007f7a4def7b41 in __GI_abort () at abort.c:79
 #2  0x00007f7a4df3835b in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7f7a4e03f885 "%s\n") at ../sysdeps/posix/libc_fatal.c:181
 #3  0x00007f7a4df3eaca in malloc_printerr (str=str@entry=0x7f7a4e040b08 "corrupted size vs. prev_size while consolidating") at malloc.c:5390
 #4  0x00007f7a4df3f910 in _int_free (av=0x7f7a4e06eaa0 <main_arena>, p=0x55f837b201f0, have_lock=<optimized out>) at malloc.c:4332
 #5  0x00007f7a4e2e4796 in magazine_cache_trim (stamp=<optimized out>, ix=<optimized out>, allocator=0x7f7a4e399dc0 <allocator>) at ../glib/gslice.c:678
 #6  magazine_cache_push_magazine (ix=<optimized out>, magazine_chunks=<optimized out>, count=51) at ../glib/gslice.c:709
 #7  0x00007f7a4e2e483c in thread_memory_magazine2_unload (tmem=tmem@entry=0x55f837af3660, ix=ix@entry=1) at ../glib/gslice.c:808
 #8  0x00007f7a4e2e5dd9 in g_slice_free_chain_with_offset (mem_size=24, mem_chain=<optimized out>, next_offset=8) at ../glib/gslice.c:1198
 #9  0x00007f7a4e2c2502 in g_list_free (list=<optimized out>) at ../glib/glist.c:182
 #10 0x000055f836036210 in free_cpu_topo (data=0x55f837b77100) at cputree.c:544
 #11 0x00007f7a4e2c2f6d in g_list_foreach (list=<optimized out>, list@entry=0x55f837b970c0, func=0x55f836036200 <free_cpu_topo>, user_data=user_data@entry=0x0) at ../glib/glist.c:1069
 #12 0x00007f7a4e2c2f9b in g_list_free_full (list=0x55f837b970c0, free_func=<optimized out>) at ../glib/glist.c:223
 #13 0x000055f83603780b in clear_cpu_tree () at cputree.c:559
 #14 0x000055f83603873d in free_object_tree () at irqbalance.c:248
 #15 0x000055f83603bb04 in scan (data=data@entry=0x0) at irqbalance.c:301
 #16 0x00007f7a4e2c768d in g_timeout_dispatch (source=0x55f837afd000, callback=0x55f83603baa0 <poll_hint_affinity_and_scan>, user_data=0x0) at ../glib/gmain.c:4705
 #17 0x00007f7a4e2c6ba4 in g_main_dispatch (context=0x55f837b39af0) at ../glib/gmain.c:3216
 #18 g_main_context_dispatch (context=context@entry=0x55f837b39af0) at ../glib/gmain.c:3881
 #19 0x00007f7a4e2c6f40 in g_main_context_iterate (context=0x55f837b39af0, block=block@entry=1, dispatch=dispatch@entry=1, self=self@entry=0x55f837b38000) at ../glib/gmain.c:3954
 #20 0x00007f7a4e2c721d in g_main_loop_run (loop=0x55f837afc3e0) at ../glib/gmain.c:4148
 #21 0x000055f836032ec8 in main (argc=3, argv=<optimized out>) at irqbalance.c:706
(gdb) x/128gx 0x55f837b20180
0x55f837b20180: 0x0000000000000000      0x0000000100000000
0x55f837b20190: 0x0000000000000000      0x000055f837b275d0
0x55f837b201a0: 0x0000000000000000      0x0000000000000051
0x55f837b201b0: 0x312c30312c392c34      0x2c37312c35312c33
0x55f837b201c0: 0x37322c34322c3232      0x332c32332c30332c
0x55f837b201d0: 0x2c34342c30342c38      0x39342c38342c3634
0x55f837b201e0: 0x352c32342c31322c      0x332c33322c312c32
0x55f837b201f0: 0x2c30322c32352c31      0x0000000000000001
0x55f837b20200: 0x000055f837bf23f0      0x000055f837b7c870
0x55f837b20210: 0x0000000000000000      0x0000000000000000
(gdb) p (char*)0x55f837b201b0
$1 = 0x55f837b201b0 "4,9,10,13,15,17,22,24,27,30,32,38,40,44,46,48,49,21,42,52,1,23,31,52,20,\001"

asan log:
==3703578==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60600000011e at pc 0x7f86ade5687e bp 0x7ffce9f7ff60 sp 0x7ffce9f7f708
READ of size 63 at 0x60600000011e thread T0
  #0 0x7f86ade5687d (/usr/lib64/libasan.so.4+0x5387d)  ??:?
  #1 0x56438e80affe (/usr/sbin/irqbalance+0x11ffe)  /usr/src/debug/irqbalance-1.8.0.x86_64/cputree.c:121
  #2 0x56438e80e97a (/usr/sbin/irqbalance+0x1597a)  /usr/src/debug/irqbalance-1.8.0.x86_64/irqbalance.c:241
  #3 0x56438e8167f7 (/usr/sbin/irqbalance+0x1d7f7)  /usr/src/debug/irqbalance-1.8.0.x86_64/irqbalance.c:308
  #4 0x7f86add1568c (/usr/lib64/libglib-2.0.so.0+0x5168c)  ??:?
  #5 0x7f86add14ba3 in g_main_context_dispatch (/usr/lib64/libglib-2.0.so.0+0x50ba3)  ??:?
  #6 0x7f86add14f3f (/usr/lib64/libglib-2.0.so.0+0x50f3f)  ??:?
  #7 0x7f86add1521c in g_main_loop_run (/usr/lib64/libglib-2.0.so.0+0x5121c)  ??:?
  #8 0x56438e8025e2 (/usr/sbin/irqbalance+0x95e2)  /usr/src/debug/irqbalance-1.8.0.x86_64/irqbalance.c:706
  #9 0x7f86ad930c86 in __libc_start_main (/usr/lib64/libc.so.6+0x25c86)  /usr/src/debug/glibc-2.28/csu/../csu/libc-start.c:308
  #10 0x56438e802919 (/usr/sbin/irqbalance+0x9919)  ??:?

0x60600000011e is located 0 bytes to the right of 62-byte region [0x6060000000e0,0x60600000011e)
allocated by thread T0 here:
  #0 0x7f86adee3e70 in __interceptor_malloc (/usr/lib64/libasan.so.4+0xe0e70)  ??:?
  #1 0x56438e80dfa8 (/usr/sbin/irqbalance+0x14fa8)  /usr/src/debug/irqbalance-1.8.0.x86_64/irqbalance.c:505
  #2 0x56438e81ab7f (/usr/sbin/irqbalance+0x21b7f)  ??:0