### PR TITLE
Confine irqbalance to systems where it is useful.

### DIFF
--- a/misc/irqbalance.service
+++ b/misc/irqbalance.service
@@ -3,6 +3,7 @@ Description=irqbalance daemon
 Documentation=man:irqbalance(1)
 Documentation=https://github.com/Irqbalance/irqbalance
 ConditionVirtualization=!container
+ConditionCPUs=>1
 
 [Service]
 EnvironmentFile=-/usr/lib/irqbalance/defaults.env


### PR DESCRIPTION
Systems with only one CPU cannot benefit from this service, so
don't start it when it isn't worth the resource consumption.