### PR TITLE
check whether savedptr is NULL before invoking strlen

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -178,7 +178,7 @@ void init_irq_class_and_type(char *savedline, struct irq_info *info, int irq)
 	}
 
 #ifdef AARCH64
-	if (strlen(savedptr) > 0) {
+	if (savedptr && strlen(savedptr) > 0) {
 		snprintf(irq_fullname, PATH_MAX, "%s %s", last_token, savedptr);
 		tmp = strchr(irq_fullname, '\n');
 		if (tmp)


### PR DESCRIPTION
savedptr can be null in musl libc, so the strlen(NULL) will segfault

https://github.com/Irqbalance/irqbalance/issues/209

Signed-off-by: Chao Liu <liuchao173@huawei.com>