### PR TITLE
add keep_going check to prevent irqbalance from failing to exit after SIGTERM

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -290,7 +290,7 @@ gboolean scan(gpointer data __attribute__((unused)))
 
 
 	/* cope with cpu hotplug -- detected during /proc/interrupts parsing */
-	while (need_rescan || need_rebuild) {
+	while (keep_going && (need_rescan || need_rebuild)) {
 		int try_times = 0;
 
 		need_rescan = 0;


### PR DESCRIPTION
https://github.com/Irqbalance/irqbalance/issues/214

Signed-off-by: Liu Chao <liuchao173@huawei.com>