### PR TITLE
parse_proc_interrupts: fix parsing interrupt counts

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -331,7 +331,7 @@ void parse_proc_interrupts(void)
 		while (1) {
 			uint64_t C;
 			C = strtoull(c, &c2, 10);
-			if (c==c2) /* end of numbers */
+			if (c==c2 || !strchr(" \t", *c2)) /* end of numbers */
 				break;
 			count += C;
 			c=c2;


### PR DESCRIPTION
The name of an interrupt chip can start with a number, stop before it.
