### PR TITLE
irqbalance-ui: can't change window when in editing state

### DIFF
--- a/ui/ui.h
+++ b/ui/ui.h
@@ -13,7 +13,6 @@
 
 extern GList *tree;
 extern setup_t setup;
-extern int is_tree;
 
 void show_frame();
 void show_footer();
@@ -29,6 +28,7 @@ void display_banned_cpus();
 int toggle_cpu(GList *cpu_list, int cpu_number);
 void get_new_cpu_ban_values(cpu_ban_t *cpu, void *data);
 void get_cpu();
+void handle_sleep_setting();
 void handle_cpu_banning();
 
 void copy_assigned_obj(int *number, void *data);


### PR DESCRIPTION
when invoking setup_irqs in settings or invoking settings in setup_irqs, it
doesn't break but enters another while loop.
For example:
 \# gdb program `pidof irqbalance-ui`
 (gdb) bt
 \# 0  0x0000ffffb0dcc7b0 in poll () from /usr/lib64/libc.so.6
 \# 1  0x0000ffffb0e9097c in _nc_timed_wait () from /usr/lib64/libtinfo.so.6
 \# 2  0x0000ffffb0ecc154 in _nc_wgetch () from /usr/lib64/libncursesw.so.6
 \# 3  0x0000ffffb0eccb18 in wgetch () from /usr/lib64/libncursesw.so.6
 \# 4  0x00000000004045d4 in setup_irqs () at ui/ui.c:637
 \# 5  0x0000000000404084 in settings () at ui/ui.c:614
 \# 6  0x0000000000404084 in settings () at ui/ui.c:614
 \# 7  0x0000000000404084 in settings () at ui/ui.c:614
 \# 8  0x0000000000404084 in settings () at ui/ui.c:614
 \# 9  0x0000000000404084 in settings () at ui/ui.c:614
 \# 10 0x0000000000404084 in settings () at ui/ui.c:614
 \# 11 0x0000000000404084 in settings () at ui/ui.c:614
 \# 12 0x0000000000401fac in key_loop (data=<optimized out>) at ui/irqbalance-ui.c:387
 \# 13 0x0000ffffb105371c in ?? () from /usr/lib64/libglib-2.0.so.0
 \# 14 0x0000ffffb1052a84 in g_main_context_dispatch () from /usr/lib64/libglib-2.0.so.0
 \# 15 0x0000ffffb1052e38 in ?? () from /usr/lib64/libglib-2.0.so.0
 \# 16 0x0000ffffb1053188 in g_main_loop_run () from /usr/lib64/libglib-2.0.so.0
 \# 17 0x000000000040196c in main (argc=<optimized out>, argv=<optimized out>) at ui/irqbalance-ui.c:445

Signed-off-by: Liu Chao <liuchao173@huawei.com>