### PR TITLE
Avoid double free on deinit_thermal()

### DIFF
--- a/thermal.c
+++ b/thermal.c
@@ -506,8 +506,14 @@ static gboolean set_netlink_nonblocking(void)
 
 void deinit_thermal(void)
 {
-	nl_cb_put(callback);
-	nl_socket_free(sock);
+	if (callback) {
+		nl_cb_put(callback);
+		callback = NULL;
+	}
+	if (sock) {
+		nl_socket_free(sock);
+		sock = NULL;
+	}
 }
 
 /*


### PR DESCRIPTION
init_thermal() calls deinit_thermal() on error condition, as well as main() calls deinit_thermal() again, causing a double-free.

Signed-off-by: Dirk Müller <dirk@dmllr.de>