### PR TITLE
allow AF_NETLINK in the systemd service restrictions

### DIFF
--- a/misc/irqbalance.service
+++ b/misc/irqbalance.service
@@ -11,7 +11,7 @@ EnvironmentFile=-/path/to/irqbalance.env
 ExecStart=/usr/sbin/irqbalance --foreground $IRQBALANCE_ARGS
 ReadOnlyPaths=/
 ReadWritePaths=/proc/irq
-RestrictAddressFamilies=AF_UNIX
+RestrictAddressFamilies=AF_UNIX AF_NETLINK
 RuntimeDirectory=irqbalance/
 
 [Install]


### PR DESCRIPTION
AF_NETLINK is needed for communicating with the thermald daemon, without that the start up logs a warning

  thermal: socket bind failed, thermald may not be running.

because systemd prevents access to NETLINK.