### PR TITLE
thermal: Fix the warning message

### DIFF
--- a/thermal.c
+++ b/thermal.c
@@ -99,7 +99,7 @@ static gboolean prepare_netlink(void)
 
 	rc = genl_connect(sock);
 	if (rc) {
-		log(TO_ALL, LOG_INFO, "thermal: socket bind failed, thermald may not be running.\n");
+		log(TO_ALL, LOG_INFO, "thermal: socket bind failed.\n");
 		return TRUE;
 	}
 


### PR DESCRIPTION
The commit febe697ac321 ("change the log level in thermal.c from error to warning") happens to insert an unneeded message: "thermald may not be running."

This is not true because the events come from the kernel and Netlink has the multicast subscription model. So it has nothing to do with thermald.

Signed-off-by: Chang S. Bae <chang.seok.bae@intel.com>