### PR TITLE
procinterrupts: Fix IRQ name parsing on certain arm64 SoC

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -178,12 +178,14 @@ void init_irq_class_and_type(char *savedline, struct irq_info *info, int irq)
 	}
 
 #ifdef AARCH64
-	if (savedptr && strlen(savedptr) > 0) {
+	if (savedptr && strlen(savedptr) > 0)
 		snprintf(irq_fullname, PATH_MAX, "%s %s", last_token, savedptr);
-		tmp = strchr(irq_fullname, '\n');
-		if (tmp)
-			*tmp = 0;
-	}
+	else
+		snprintf(irq_fullname, PATH_MAX, "%s", last_token);
+
+	tmp = strchr(irq_fullname, '\n');
+	if (tmp)
+		*tmp = 0;
 #else
 	snprintf(irq_fullname, PATH_MAX, "%s", last_token);
 #endif


### PR DESCRIPTION
On arm64 SoCs like TI's K3 SoC and few other SoCs, IRQ names don't get parsed correct due to which they end up being classified into wrong class. Fix this by considering last token to contain IRQ name always.

Eg.: /proc/interrupt

cat /proc/interrupts
           CPU0       CPU1       CPU2       CPU3
 11:       7155       8882       7235       7791     GICv3  30 Level     arch_timer
 14:          0          0          0          0     GICv3  23 Level     arm-pmu
 15:          0          0          0          0     GICv3 208 Level     4b00000.spi
 16:          0          0          0          0     GICv3 209 Level     4b10000.spi
116:          0          0          0          0  MSI-INTA 1716234 Level     485c0100.dma-controller chan6
134:        166          0          0          0  MSI-INTA 1970707 Level     8000000.ethernet-tx0
224:        149          0          0          0  MSI-INTA 1971731 Level     8000000.ethernet

W/o patch irqbalance -d
IRQ (11) guessed as class 0
IRQ (14) guessed as class 0
IRQ (15) guessed as class 0
IRQ (16) guessed as class 0
IRQ 485c0100.dma-controller chan6(116) guessed as class 0 IRQ (134) guessed as class 0
IRQ (224) guessed as class 0

W/ this patch
IRQ arch_timer(11) guessed as class 0
IRQ arm-pmu(14) guessed as class 0
IRQ 4b00000.spi(15) guessed as class 0
IRQ 4b10000.spi(16) guessed as class 0
IRQ 485c0100.dma-controller chan6(116) guessed as class 0 IRQ 8000000.ethernet-tx0(134) guessed as class 5
IRQ 8000000.ethernet(224) guessed as class 5
IRQ 8000000.ethernet(257) guessed as class 5
IRQ -davinci_gpio  wl18xx(362) guessed as class

Signed-off-by: Vignesh Raghavendra <vigneshr@ti.com>