### PR TITLE
irqbalance: fix memory leak in irq hotplug path

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -778,6 +778,8 @@ int proc_irq_hotplug(char *savedline, int irq, struct irq_info **pinfo)
 		/* secondly, init irq info by parse savedline */
 		init_irq_class_and_type(savedline, &tmp_info, irq);
 		add_new_irq(NULL, &tmp_info);
+		free(tmp_info.name);
+
 		*pinfo = get_irq_info(irq);
 	}
 	if (*pinfo == NULL) {


### PR DESCRIPTION
tmp_info.name duplicate a name string in init_irq_class_and_type(), free() it before return.