### PR TITLE
Fix CPU number condition in service file

### DIFF
--- a/misc/irqbalance.service
+++ b/misc/irqbalance.service
@@ -3,7 +3,7 @@ Description=irqbalance daemon
 Documentation=man:irqbalance(1)
 Documentation=https://github.com/Irqbalance/irqbalance
 ConditionVirtualization=!container
-ConditionCPUs=>1
+ConditionCPUs>1
 
 [Service]
 EnvironmentFile=-/usr/lib/irqbalance/defaults.env


### PR DESCRIPTION
Modified to start only when there are 2 or more CPUs, as intended in the original pull request (https://github.com/Irqbalance/irqbalance/pull/201).