### PR TITLE
Issue 259: select NL_SKIP / NL_STOP based on error

### DIFF
--- a/thermal.c
+++ b/thermal.c
@@ -190,7 +190,7 @@ static int handle_groupid(struct nl_msg *msg, void *arg)
 static int handle_error(struct sockaddr_nl *sk_addr __attribute__((unused)),
 			struct nlmsgerr *err, void *arg)
 {
-	int rc = (err->error == -NLE_INTR) ? NL_SKIP : NL_STOP;
+	int rc = (err->error == -NLE_INTR) ? NL_STOP : NL_SKIP;
 
 	if (arg && err->error != -NLE_INTR) {
 		log(TO_ALL, LOG_INFO, "thermal: received a netlink error (%s).\n",

--- a/thermal.c
+++ b/thermal.c
@@ -190,9 +190,9 @@ static int handle_groupid(struct nl_msg *msg, void *arg)
 static int handle_error(struct sockaddr_nl *sk_addr __attribute__((unused)),
 			struct nlmsgerr *err, void *arg)
 {
-	int rc = (err->error == NLE_INTR) ? NL_SKIP : NL_STOP;
+	int rc = (err->error == -NLE_INTR) ? NL_SKIP : NL_STOP;
 
-	if (arg && err->error != NLE_INTR) {
+	if (arg && err->error != -NLE_INTR) {
 		log(TO_ALL, LOG_INFO, "thermal: received a netlink error (%s).\n",
 		    nl_geterror(err->error));
 		*((int *)arg) = err->error;

--- a/thermal.c
+++ b/thermal.c
@@ -190,12 +190,14 @@ static int handle_groupid(struct nl_msg *msg, void *arg)
 static int handle_error(struct sockaddr_nl *sk_addr __attribute__((unused)),
 			struct nlmsgerr *err, void *arg)
 {
-	if (arg) {
+	int rc = (err->error == NLE_INTR) ? NL_SKIP : NL_STOP;
+
+	if (arg && err->error != NLE_INTR) {
 		log(TO_ALL, LOG_INFO, "thermal: received a netlink error (%s).\n",
 		    nl_geterror(err->error));
 		*((int *)arg) = err->error;
 	}
-	return NL_SKIP;
+	return rc;
 }
 
 static int handle_end(struct nl_msg *msg __attribute__((unused)), void *arg)


### PR DESCRIPTION
the handle_error function for thermal should skip EINTR errors, but stop for everything else