### PR TITLE
Revert "Fix CPU number condition in service file"

### DIFF
--- a/misc/irqbalance.service
+++ b/misc/irqbalance.service
@@ -3,7 +3,7 @@ Description=irqbalance daemon
 Documentation=man:irqbalance(1)
 Documentation=https://github.com/Irqbalance/irqbalance
 ConditionVirtualization=!container
-ConditionCPUs>1
+ConditionCPUs=>1
 
 [Service]
 EnvironmentFile=-/usr/lib/irqbalance/defaults.env


### PR DESCRIPTION
Reverts Irqbalance/irqbalance#257
I was misunderstanding the syntax of the unit file. The original line was reflecting the condition as intended.