### PR TITLE
procinterrupts: fix initialisation of regex_t struct

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -107,10 +107,10 @@ static void guess_arm_irq_hints(char *name, struct irq_info *info)
 	static int compiled = 0;
 	/* Note: Last entry is a catchall */
 	static struct irq_match matches[] = {
-		{ "eth.*" ,{NULL} ,NULL, IRQ_TYPE_LEGACY, IRQ_GBETH },
-		{ "[A-Z0-9]{4}[0-9a-f]{4}", {NULL} ,check_platform_device, IRQ_TYPE_LEGACY, IRQ_OTHER},
-		{ "PNP[0-9a-f]{4}", {NULL} ,check_platform_device, IRQ_TYPE_LEGACY, IRQ_OTHER},
-		{ ".*", {NULL}, NULL, IRQ_TYPE_LEGACY, IRQ_OTHER},
+		{ "eth.*" , {0},NULL, IRQ_TYPE_LEGACY, IRQ_GBETH },
+		{ "[A-Z0-9]{4}[0-9a-f]{4}", {0}, check_platform_device, IRQ_TYPE_LEGACY, IRQ_OTHER},
+		{ "PNP[0-9a-f]{4}", {0}, check_platform_device, IRQ_TYPE_LEGACY, IRQ_OTHER},
+		{ ".*", {0}, NULL, IRQ_TYPE_LEGACY, IRQ_OTHER},
 		{NULL},
 	};
 


### PR DESCRIPTION
```
{NULL} utilises the null pointer, but this is not valid, because null is a pointer:

procinterrupts.c:110:29: error: initialization of 'long unsigned int' from 'void *' makes integer from pointer without a cast [-Werror=int-conversion]
  110 |                 { "eth.*" ,{NULL} ,NULL, IRQ_TYPE_LEGACY, IRQ_GBETH },

0-initialisation should be done with '0' instead of a pointer.
```