### PR TITLE
activate_mapping: report explicit errors on failure

### DIFF
--- a/activate.c
+++ b/activate.c
@@ -86,10 +86,17 @@ static void activate_mapping(struct irq_info *info, void *data __attribute__((un
 	info->moved = 0; /*migration is done*/
 	return;
 error:
-	log(TO_ALL, LOG_WARNING, "cannot change irq %i's affinity: %s. add it to banned list",
+	log(TO_ALL, LOG_WARNING, "cannot change irq %i's affinity: %s",
 		info->irq, strerror(errno));
-	add_banned_irq(info->irq);
-	remove_one_irq_from_db(info->irq);
+	if (errno != ENOSPC) {
+		/*
+		 * Do not ban the IRQ if the APIC reports a transient out of
+		 * space error.
+		 */
+		log(TO_ALL, LOG_WARNING, "adding irq %i to ban list", info->irq);
+		add_banned_irq(info->irq);
+		remove_one_irq_from_db(info->irq);
+	}
 }
 
 void activate_mappings(void)


### PR DESCRIPTION
Make sure to report the exact reason why the affinity cannot be enforced. No need to call fflush() since it is called internally in fclose().

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2184735

This is a follow up on #265 