### PR TITLE
Revert "arm64: Add irq aff change check"

### DIFF
--- a/activate.c
+++ b/activate.c
@@ -48,7 +48,6 @@ static void activate_mapping(struct irq_info *info, void *data __attribute__((un
 {
 	char buf[PATH_MAX];
 	FILE *file;
-	int ret = 0;
 	cpumask_t applied_mask;
 
 	/*
@@ -75,12 +74,7 @@ static void activate_mapping(struct irq_info *info, void *data __attribute__((un
 		return;
 
 	cpumask_scnprintf(buf, PATH_MAX, applied_mask);
-	ret = fprintf(file, "%s", buf);
-	if (ret < 0) {
-		log(TO_ALL, LOG_WARNING, "cannot change irq %i's affinity, add it to banned list", info->irq);
-		add_banned_irq(info->irq);
-		remove_one_irq_from_db(info->irq);
-	}
+	fprintf(file, "%s", buf);
 	fclose(file);
 	info->moved = 0; /*migration is done*/
 }

--- a/classify.c
+++ b/classify.c
@@ -257,7 +257,7 @@ static gint compare_ints(gconstpointer a, gconstpointer b)
 	return ai->irq - bi->irq;
 }
 
-static void __add_banned_irq(int irq, GList **list)
+static void add_banned_irq(int irq, GList **list)
 {
 	struct irq_info find, *new;
 	GList *entry;
@@ -281,14 +281,9 @@ static void __add_banned_irq(int irq, GList **list)
 	return;
 }
 
-void add_banned_irq(int irq)
-{
-	__add_banned_irq(irq, &banned_irqs);
-}
-
 void add_cl_banned_irq(int irq)
 {
-	__add_banned_irq(irq, &cl_banned_irqs);
+	add_banned_irq(irq, &cl_banned_irqs);
 }
 
 gint substr_find(gconstpointer a, gconstpointer b)
@@ -390,23 +385,6 @@ get_numa_node:
 
 	log(TO_CONSOLE, LOG_INFO, "Adding IRQ %d to database\n", irq);
 	return new;
-}
-
-void remove_one_irq_from_db(int irq)
-{
-	struct irq_info find, *tmp;
-	GList *entry = NULL;
-
-	find.irq = irq;
-	entry = g_list_find_custom(interrupts_db, &find, compare_ints);
-	if (!entry)
-		return;
-
-	tmp = entry->data;
-	interrupts_db = g_list_remove(interrupts_db, tmp);
-	free(tmp);
-	log(TO_CONSOLE, LOG_INFO, "IRQ %d was removed from db.\n", irq);
-	return;
 }
 
 static void parse_user_policy_key(char *buf, int irq, struct user_irq_policy *pol)
@@ -629,7 +607,7 @@ static void add_new_irq(char *path, struct irq_info *hint)
 	/* Set NULL devpath for the irq has no sysfs entries */
 	get_irq_user_policy(path, irq, &pol);
 	if ((pol.ban == 1) || check_for_irq_ban(hint, mod)) { /*FIXME*/
-		__add_banned_irq(irq, &banned_irqs);
+		add_banned_irq(irq, &banned_irqs);
 		new = get_irq_info(irq);
 	} else
 		new = add_one_irq_to_db(path, hint, &pol);

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -109,8 +109,6 @@ extern struct irq_info *get_irq_info(int irq);
 extern void migrate_irq(GList **from, GList **to, struct irq_info *info);
 extern void free_cl_opts(void);
 extern void add_cl_banned_module(char *modname);
-extern void add_banned_irq(int irq);
-extern void remove_one_irq_from_db(int irq);
 #define irq_numa_node(irq) ((irq)->numa_node)
 
 


### PR DESCRIPTION
This reverts commit 55c5c321c73e4c9b54e041ba8c7d542598685bae.

The banned_irqs list is meant to be configured by the user, it is not a dynamic list. Also, remove_one_irq_from_db() was freeing an irq_info struct which was still referenced in banned_irqs and potentially in rebalance_irq_list.

Iterating on any of these lists will cause a use after free error.

Fixes: https://github.com/Irqbalance/irqbalance/issues/267