### PR TITLE
Automatically use systemd journal logging if run under systemd

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -617,6 +617,16 @@ int main(int argc, char** argv)
 	parse_command_line(argc, argv);
 
 	/*
+	 * Check if we are run under systemd and enable journal_logging
+	 * and run in foreground if so. Systemd v232 or later will set
+	 * INVOCATION_ID.
+	 */
+	if (getenv("INVOCATION_ID")) {
+		journal_logging=1;
+		foreground_mode=1;
+	}
+
+	/*
  	 * Open the syslog connection
  	 */
 	openlog(argv[0], 0, LOG_DAEMON);

--- a/misc/irqbalance.service
+++ b/misc/irqbalance.service
@@ -8,7 +8,7 @@ ConditionCPUs=>1
 [Service]
 EnvironmentFile=-/usr/lib/irqbalance/defaults.env
 EnvironmentFile=-/path/to/irqbalance.env
-ExecStart=/usr/sbin/irqbalance --foreground $IRQBALANCE_ARGS
+ExecStart=/usr/sbin/irqbalance $IRQBALANCE_ARGS
 ReadOnlyPaths=/
 ReadWritePaths=/proc/irq
 RestrictAddressFamilies=AF_UNIX AF_NETLINK


### PR DESCRIPTION
This is an alternative to https://github.com/Irqbalance/irqbalance/pull/277