### PR TITLE
Improvements for meson build system

### DIFF
--- a/contrib/meson.build
+++ b/contrib/meson.build
@@ -1,4 +1,4 @@
-project('irqbalance', 'c', version: '1.9.0', default_options: ['warning_level=1'])
+project('irqbalance', 'c', version: '1.9.3', default_options: ['warning_level=1'])
 cc = meson.get_compiler('c')
 
 glib_dep = dependency('glib-2.0')

--- a/contrib/meson.build
+++ b/contrib/meson.build
@@ -28,6 +28,13 @@ if cdata.get('HAVE_IRQBALANCEUI')
     dependencies: [glib_dep, ncurses_dep],
     install: true,
   )
+
+  install_man(
+    '../irqbalance-ui.1',
+    install_dir: get_option('mandir') + '/man1',
+    install_mode: 'rw-r--r--',
+    locale: 'en',
+  )
 endif
 
 executable(
@@ -43,4 +50,11 @@ executable(
   '../procinterrupts.c',
   dependencies: [glib_dep, m_dep, capng_dep, numa_dep, systemd_dep],
   install: true,
+)
+
+install_man(
+  '../irqbalance.1',
+  install_dir: get_option('mandir') + '/man1',
+  install_mode: 'rw-r--r--',
+  locale: 'en',
 )

--- a/contrib/meson.build
+++ b/contrib/meson.build
@@ -5,6 +5,7 @@ glib_dep = dependency('glib-2.0')
 m_dep = cc.find_library('m', required: false)
 capng_dep = dependency('libcap-ng', required: get_option('capng'))
 ncurses_dep = dependency('curses', required: get_option('ui'))
+numa_dep = dependency('numa')
 systemd_dep = dependency('libsystemd', required: get_option('systemd'))
 
 cdata = configuration_data()
@@ -40,6 +41,6 @@ executable(
   '../numa.c',
   '../placement.c',
   '../procinterrupts.c',
-  dependencies: [glib_dep, m_dep, capng_dep, systemd_dep],
+  dependencies: [glib_dep, m_dep, capng_dep, numa_dep, systemd_dep],
   install: true,
 )


### PR DESCRIPTION
Hi! :wave: 
I package this project for Arch Linux and would be *very much interested* in using meson instead of autotools for packaging! :tada: 

I fixed the build to link against numa, install the man pages and set the correct project version.

I'd be happy if this could be merged and the meson build system files be eventually moved to the root of the repository, so that it is easier to find them (I only now noticed by accident)!