### PR TITLE
Slience "... rebalancing" messages for unmigratable IRQs

### DIFF
--- a/activate.c
+++ b/activate.c
@@ -62,9 +62,6 @@ static void activate_mapping(struct irq_info *info, void *data __attribute__((un
 	if (!info->assigned_obj)
 		return;
 
-	if (info->flags & IRQ_FLAG_AFFINITY_UNMANAGED)
-		return;
-
 	/* activate only online cpus, otherwise writing to procfs returns EOVERFLOW */
 	cpus_and(applied_mask, cpu_online_map, info->assigned_obj->mask);
 
@@ -105,7 +102,8 @@ error:
 		break;
 	default:
 		/* Any other error is considered permanent. */
-		info->flags |= IRQ_FLAG_AFFINITY_UNMANAGED;
+		info->level = BALANCE_NONE;
+		info->moved = 0; /* migration impossible, mark as done */
 		log(TO_ALL, LOG_WARNING, "IRQ %i affinity is now unmanaged\n",
 			info->irq);
 	}

--- a/irqlist.c
+++ b/irqlist.c
@@ -78,7 +78,7 @@ static void move_candidate_irqs(struct irq_info *info, void *data)
 	struct load_balance_info *lb_info = data;
 	unsigned long delta_load = 0;
 
-	/* Don't rebalance irqs that don't want it */
+	/* Don't rebalance irqs that don't want or support it */
 	if (info->level == BALANCE_NONE)
 		return;
 

--- a/types.h
+++ b/types.h
@@ -35,7 +35,6 @@
  * IRQ Internal tracking flags
  */
 #define IRQ_FLAG_BANNED                 (1ULL << 0)
-#define IRQ_FLAG_AFFINITY_UNMANAGED     (1ULL << 1)
 
 enum obj_type_e {
 	OBJ_TYPE_CPU,


### PR DESCRIPTION
It is fairly pointless to try migrating an IRQ which is known to be unmigratable.

Instead of using an extra flag, set the `level` to BALANCE_NONE, which shortcuts quite some code, and implicitly also disables the misleading repeated log message:

```
Dez 10 02:52:55 varm irqbalance[828]: Selecting irq 75 for rebalancing
Dez 10 02:52:55 varm irqbalance[828]: Cannot change IRQ 75 affinity: Input/output error
Dez 10 02:52:55 varm irqbalance[828]: IRQ 75 affinity is now unmanaged
...
Dez 10 02:52:55 varm irqbalance[828]: Selecting irq 75 for rebalancing
...
Dez 10 02:52:55 varm irqbalance[828]: Selecting irq 75 for rebalancing
```