### PR TITLE
Avoid repeated affinity checks when no change is necessary

### DIFF
--- a/activate.c
+++ b/activate.c
@@ -68,8 +68,10 @@ static void activate_mapping(struct irq_info *info, void *data __attribute__((un
 	/*
  	 * Don't activate anything for which we have an invalid mask 
  	 */
-	if (check_affinity(info, applied_mask))
+	if (check_affinity(info, applied_mask)) {
+		info->moved = 0; /* nothing to do, mark as done */
 		return;
+	}
 
 	sprintf(buf, "/proc/irq/%i/smp_affinity", info->irq);
 	file = fopen(buf, "w");


### PR DESCRIPTION
An IRQ may be migrated several times during one loop iteration, and end up with the same CPU affinity mask as before - the "moved" flag is merely a hint a affinity change may be necessary. This notably also happens during initial placement, but may happen also anytime later.

To avoid visiting each IRQ again and again unset the "moved" flag. This avoids the open/stat/read/close syscalls for unchanged interrupts.

Fixes: #285