### PR TITLE
activate_mapping: set errsave before first jump to the error label

### DIFF
--- a/activate.c
+++ b/activate.c
@@ -73,6 +73,7 @@ static void activate_mapping(struct irq_info *info, void *data __attribute__((un
 
 	sprintf(buf, "/proc/irq/%i/smp_affinity", info->irq);
 	file = fopen(buf, "w");
+	errsave = errno;
 	if (!file)
 		goto error;
 


### PR DESCRIPTION
if the fopen fails, errsave is used uninitialized

https://github.com/Irqbalance/irqbalance/issues/287