### PR TITLE
Stop log spam due to debug message from scan

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -289,7 +289,7 @@ gboolean force_rescan(gpointer data __attribute__((unused)))
 
 gboolean scan(gpointer data __attribute__((unused)))
 {
-	log(TO_CONSOLE, LOG_INFO, "\n\n\n-----------------------------------------------------------------------------\n");
+	log(TO_CONSOLE, LOG_DEBUG, "----- Enter: %s -----\n", __func__);
 	clear_work_stats();
 	parse_proc_interrupts();
 


### PR DESCRIPTION
Currently systems encounter log spam every 10 seconds due to a message meant for debugging now being forwarded to journald. Users get three empty lines followed by 78 "-" without any further info what this is about.

```
Jan 05 12:31:25 n-vm irqbalance[770]: 
                                      
                                      
                                      -----------------------------------------------------------------------------
Jan 05 12:31:35 n-vm irqbalance[770]: 
                                      
                                      
                                      -----------------------------------------------------------------------------
Jan 05 12:31:45 n-vm irqbalance[770]: 
                                      
                                      
                                      -----------------------------------------------------------------------------
```

Due to its original debug-only purpose the message also grabs a lot of screen-estate. So while touching it anyway let us also make it a bit less agressive (no three lead line breaks, less width), now it is like:
```
----- Enter: scan -----
```

Fixes: #292

I was just seeing this and tried to provide a simple fix, I do not insist on the wording, the style or anything.
All I want is to get the log spam stopped, so please feel free to modify it along the way if you'd want it to look different.