### PR TITLE
irqbalance-ui: check if using a negative index of buffer

### DIFF
--- a/ui/irqbalance-ui.c
+++ b/ui/irqbalance-ui.c
@@ -127,9 +127,13 @@ try_again:
 	char *data = malloc(default_bufsz);
 	int len = recv(socket_fd, data, default_bufsz, MSG_TRUNC);
 	close(socket_fd);
-	data[len] = '\0';
 	free(msg->msg_control);
 	free(msg);
+	if (len < 0) {
+		free(data);
+		return NULL;
+	}
+	data[len] = '\0';
 	if (len >= default_bufsz) {
 		/* msg was truncated, increase bufsz and try again */
 		default_bufsz += 8192;


### PR DESCRIPTION
A negative index will be used when recv() fails, which is unexpected for the data buffer.