### PR TITLE
Check `fflush()` return value

### DIFF
--- a/activate.c
+++ b/activate.c
@@ -82,10 +82,13 @@ static void activate_mapping(struct irq_info *info, void *data __attribute__((un
 	cpumask_scnprintf(buf, PATH_MAX, applied_mask);
 	ret = fprintf(file, "%s", buf);
 	errsave = errno;
-	fflush(file);
-	if (fclose(file)) {
+	if (ret >= 0 && fflush(file)) {
+		ret = -1;
 		errsave = errno;
-		goto error;
+	}
+	if (fclose(file)) {
+		ret = -1;
+		errsave = errno;
 	}
 	if (ret < 0)
 		goto error;


### PR DESCRIPTION
Since `fprintf()` may buffer output, as noted in 470a64b19062, `fclose()`'s error value was also being checked for the write errors.  However in 8d7c78304fb9 an `fflush()` was added in between meaning that these buffered write errors were again unchecked.  Some actual errors were not being logged, in my case `-ENOSPCs`.

Make the fclose and fflush branches look similar.

Fixes: 8d7c78304fb9 ("Flush file before closing")