### PR TITLE
CI: add meson CI

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -1,0 +1,70 @@
+name: meson
+
+on: [pull_request, push]
+
+concurrency:
+  group: ${{github.workflow}}-${{github.head_ref}}
+  cancel-in-progress: true
+
+jobs:
+  Linux-GCC:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        cc: ['7', '13']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: egor-tensin/setup-gcc@v1
+        with:
+          version: ${{matrix.cc}}
+      - name: Install Packages
+        run: |
+          python3 -m pip install meson ninja
+          sudo apt install -y libcap-ng-dev libnl-3-dev libnl-genl-3-dev libnuma-dev libsystemd-dev
+      - name: Compile and Test
+        run: |
+          meson setup "${{github.workspace}}/build" -Dwarning_level=3
+          meson compile -C "${{github.workspace}}/build"
+          meson test -C "${{github.workspace}}/build"
+  Linux-Clang:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        cc: ['6.0', '18']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: egor-tensin/setup-clang@v1
+        with:
+          version: ${{matrix.cc}}
+      - name: Install Packages
+        run: |
+          python3 -m pip install meson ninja
+          sudo apt install -y libcap-ng-dev libnl-3-dev libnl-genl-3-dev libnuma-dev libsystemd-dev
+      - name: Compile and Test
+        run: |
+          meson setup "${{github.workspace}}/build" -Dwarning_level=3
+          meson compile -C "${{github.workspace}}/build" --verbose
+          meson test -C "${{github.workspace}}/build" --verbose
+  Alpine:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        platform: ['aarch64', 'armhf', 'armv7', 'ppc64le', 'riscv64', 's390x']
+    defaults:
+      run:
+        shell: alpine.sh {0}
+    steps:
+      - name: Get pushed code
+        uses: actions/checkout@v4
+
+      - uses: jirutka/setup-alpine@v1
+        with:
+          branch: edge
+          arch: ${{matrix.platform}}
+          packages: >
+            build-base glib-dev libcap-ng-dev libnl3-dev meson numactl-dev
+      - name: Compile and Test
+        run: |
+          meson setup "${{github.workspace}}/build" -Dwarning_level=3 -Dsystemd=disabled
+          meson compile -C "${{github.workspace}}/build"
+          meson test -C "${{github.workspace}}/build"


### PR DESCRIPTION
tests old and new Clang/GCC on x64 and Alpine Linux on various platforms.

Sample run:

https://github.com/neheb/irqbalance/actions/runs/8513901951