### PR TITLE
Try fix https://github.com/Irqbalance/irqbalance/issues/303

### DIFF
--- a/classify.c
+++ b/classify.c
@@ -883,6 +883,8 @@ static void remove_no_existing_irq(struct irq_info *info, void *data __attribute
 		entry = g_list_find_custom(info->assigned_obj->interrupts, info, compare_ints);
 	    if (entry) {
 			info->assigned_obj->interrupts = g_list_delete_link(info->assigned_obj->interrupts, entry);
+			/* Probe number of slots again, don't guess whether the IRQ left a free slot */
+			info->assigned_obj->slots_left = INT_MAX;
 		}
 	}
 	free_irq(info, NULL);

--- a/cputree.c
+++ b/cputree.c
@@ -595,3 +595,13 @@ int get_cpu_count(void)
 	return g_list_length(cpus);
 }
 
+static void clear_obj_slots(struct topo_obj *d, void *data __attribute__((unused)))
+{
+	d->slots_left = INT_MAX;
+	for_each_object(d->children, clear_obj_slots, NULL);
+}
+
+void clear_slots(void)
+{
+	for_each_object(numa_nodes, clear_obj_slots, NULL);
+}

--- a/irqbalance.c
+++ b/irqbalance.c
@@ -253,9 +253,7 @@ void force_rebalance_irq(struct irq_info *info, void *data __attribute__((unused
 	if (info->assigned_obj == NULL)
 		rebalance_irq_list = g_list_append(rebalance_irq_list, info);
 	else
-		migrate_irq(&info->assigned_obj->interrupts, &rebalance_irq_list, info);
-
-	info->assigned_obj = NULL;
+		migrate_irq_obj(info->assigned_obj, NULL, info);
 }
 
 gboolean handler(gpointer data __attribute__((unused)))

--- a/irqbalance.c
+++ b/irqbalance.c
@@ -298,6 +298,7 @@ gboolean scan(gpointer data __attribute__((unused)))
 		} while (need_rebuild);
 
 		for_each_irq(NULL, force_rebalance_irq, NULL);
+		clear_slots();
 		parse_proc_interrupts();
 		parse_proc_stat();
 		return TRUE;
@@ -694,6 +695,8 @@ int main(int argc, char** argv)
 
 	parse_proc_interrupts();
 	parse_proc_stat();
+
+	clear_slots();
 
 #ifdef HAVE_IRQBALANCEUI
 	if (init_socket()) {

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -52,6 +52,7 @@ void dump_workloads(void);
 void sort_irq_list(GList **list);
 void calculate_placement(void);
 void dump_tree(void);
+void migrate_irq_obj(struct topo_obj *from, struct topo_obj *to, struct irq_info *info);
 
 void activate_mappings(void);
 void clear_cpu_tree(void);

--- a/irqbalance.h
+++ b/irqbalance.h
@@ -98,6 +98,7 @@ extern struct topo_obj *get_numa_node(int nodeid);
 #define cpu_numa_node(cpu) ((cpu)->parent->numa_nodes)
 extern struct topo_obj *find_cpu_core(int cpunr);
 extern int get_cpu_count(void);
+extern void clear_slots(void);
 
 /*
  * irq db functions

--- a/irqlist.c
+++ b/irqlist.c
@@ -211,8 +211,17 @@ void migrate_irq_obj(struct topo_obj *from, struct topo_obj *to, struct irq_info
 
 	migrate_irq(from_list, to_list, info);
 
-	if (to)
+	if (from) {
+		if (from->slots_left != INT_MAX)
+			from->slots_left++;
+	}
+
+	if (to) {
+		if (to->slots_left != INT_MAX)
+			to->slots_left--;
+
 		to->load += info->load + 1;
+	}
 
 	info->assigned_obj = to;
 }

--- a/irqlist.c
+++ b/irqlist.c
@@ -108,9 +108,7 @@ static void move_candidate_irqs(struct irq_info *info, void *data)
 
 	log(TO_CONSOLE, LOG_INFO, "Selecting irq %d for rebalancing\n", info->irq);
 
-	migrate_irq(&info->assigned_obj->interrupts, &rebalance_irq_list, info);
-
-	info->assigned_obj = NULL;
+	force_rebalance_irq(info, NULL);
 }
 
 static void migrate_overloaded_irqs(struct topo_obj *obj, void *data)
@@ -146,12 +144,6 @@ static void migrate_overloaded_irqs(struct topo_obj *obj, void *data)
 	}
 }
 
-static void force_irq_migration(struct irq_info *info, void *data __attribute__((unused)))
-{
-	migrate_irq(&info->assigned_obj->interrupts, &rebalance_irq_list, info);
-	info->assigned_obj = NULL;
-}
-
 static void clear_powersave_mode(struct topo_obj *obj, void *data __attribute__((unused)))
 {
 	obj->powersave_mode = 0;
@@ -183,7 +175,7 @@ void update_migration_status(void)
 			log(TO_ALL, LOG_INFO, "cpu %d entering powersave mode\n", info.powersave->number);
 			info.powersave->powersave_mode = 1;
 			if (g_list_length(info.powersave->interrupts) > 0)
-				for_each_irq(info.powersave->interrupts, force_irq_migration, NULL);
+				for_each_irq(info.powersave->interrupts, force_rebalance_irq, NULL);
 		} else if ((info.num_over) && (info.num_powersave)) {
 			log(TO_ALL, LOG_INFO, "Load average increasing, re-enabling all cpus for irq balancing\n");
 			for_each_object(cpus, clear_powersave_mode, NULL);
@@ -205,3 +197,22 @@ void dump_workloads(void)
 	for_each_irq(NULL, dump_workload, NULL);
 }
 
+void migrate_irq_obj(struct topo_obj *from, struct topo_obj *to, struct irq_info *info)
+{
+
+	GList **from_list;
+	GList **to_list;
+
+	if (!from)
+		from = info->assigned_obj;
+
+	from_list = from ? &from->interrupts : &rebalance_irq_list;
+	to_list = to ? &to->interrupts : &rebalance_irq_list;
+
+	migrate_irq(from_list, to_list, info);
+
+	if (to)
+		to->load += info->load + 1;
+
+	info->assigned_obj = to;
+}

--- a/placement.c
+++ b/placement.c
@@ -59,6 +59,9 @@ static void find_best_object(struct topo_obj *d, void *data)
 	if (d->powersave_mode)
 		return;
 
+	if (d->slots_left <= 0)
+		return;
+
 	newload = d->load;
 	if (newload < best->best_cost) {
 		best->best = d;

--- a/placement.c
+++ b/placement.c
@@ -74,7 +74,6 @@ static void find_best_object_for_irq(struct irq_info *info, void *data)
 {
 	struct obj_placement place;
 	struct topo_obj *d = data;
-	struct topo_obj *asign;
 
 	if (!info->moved)
 		return;
@@ -107,13 +106,8 @@ static void find_best_object_for_irq(struct irq_info *info, void *data)
 
 	for_each_object(d->children, find_best_object, &place);
 
-	asign = place.best;
-
-	if (asign) {
-		migrate_irq(&d->interrupts, &asign->interrupts, info);
-		info->assigned_obj = asign;
-		asign->load += info->load;
-	}
+	if (place.best)
+		migrate_irq_obj(d, place.best, info);
 }
 
 static void place_irq_in_object(struct topo_obj *d, void *data __attribute__((unused)))
@@ -125,7 +119,6 @@ static void place_irq_in_object(struct topo_obj *d, void *data __attribute__((un
 static void place_irq_in_node(struct irq_info *info, void *data __attribute__((unused)))
 {
 	struct obj_placement place;
-	struct topo_obj *asign;
 
 	if ((info->level == BALANCE_NONE) && cpus_empty(banned_cpus))
 		return;
@@ -145,9 +138,7 @@ static void place_irq_in_node(struct irq_info *info, void *data __attribute__((u
 		 * This irq belongs to a device with a preferred numa node
 		 * put it on that node
 		 */
-		migrate_irq(&rebalance_irq_list, &irq_numa_node(info)->interrupts, info);
-		info->assigned_obj = irq_numa_node(info);
-		irq_numa_node(info)->load += info->load + 1;
+		migrate_irq_obj(NULL, irq_numa_node(info), info);
 
 		return;
 	}
@@ -159,13 +150,8 @@ find_placement:
 
 	for_each_object(numa_nodes, find_best_object, &place);
 
-	asign = place.best;
-
-	if (asign) {
-		migrate_irq(&rebalance_irq_list, &asign->interrupts, info);
-		info->assigned_obj = asign;
-		asign->load += info->load;
-	}
+	if (place.best)
+		migrate_irq_obj(NULL, place.best, info);
 }
 
 static void validate_irq(struct irq_info *info, void *data)

--- a/types.h
+++ b/types.h
@@ -56,6 +56,7 @@ struct topo_obj {
 	GList *children;
 	GList *numa_nodes;
 	GList **obj_type_list;
+	int slots_left;
 };
 
 struct irq_info {


### PR DESCRIPTION
This is a proposed fix for https://github.com/Irqbalance/irqbalance/issues/303 up for discussion.  Here's the relevant commit msg:

---
There are situations where irqbalance may try to migrate large numbers of
IRQs to a topo_obj, there's no upper bound on the number as the
placement logic is based on load mainly.  The kernel's irq bitmasks limit
the number of IRQs on each cpu and if more are tried to be migrated, the
write to smp_affinity returns -ENOSPC.  This confuses irqbalance's
logic, the topo_obj.interrupts list no longer matches the irqs actually
on that CPU or cache domain, and results in floods of error messages.
See https://github.com/Irqbalance/irqbalance/issues/303 for details.

For an easy fix, track the number of IRQ slots still free on each CPU.
We start with INT_MAX meaning "unknown" and when we first get a -ENOSPC,
we know we have no slots left.  From there update the slots count each
time we migrate IRQs to/from the CPU core topo_obj.  We may never see an
-ENOSPC and in that case there's no change in current logic, we never
start tracking.

This way we don't need to know ahead of time how many slots the kernel
has for each CPU.  The number may be arch specific (it is about 200 on
x86-64) and is dependent on the number managed IRQs kernel has
registered, so we don't want to guess.  This is also more tolerant to
the topo_obj.interrupts lists not matching exactly the kernel's idea of
each irq's current affinity, e.g. due to -EIO errors in the smp_affinity
writes.

For now only do the tracking at OBJ_TYPE_CPU level so we don't have to
update slots_left for all parent objs.

Th commit doesn't try to stop an ongoing activation of all the IRQs
already scheduled for moving to one cpu, when that cpu starts returning
ENOSPC.  We'll still see a bunch of those errors in that iteration.
But in subsequent calculate_placement() iterations we avoid assigning
more IRQs to that cpu than we were able to successfully move before.