### PR TITLE
Define IRQBALANCE_ARGS as empty string to squelch systemd warning

### DIFF
--- a/misc/irqbalance.env
+++ b/misc/irqbalance.env
@@ -41,4 +41,4 @@
 #    Append any args here to the irqbalance daemon as documented in the man
 #    page.
 #
-#IRQBALANCE_ARGS=
+IRQBALANCE_ARGS=""


### PR DESCRIPTION
Systemd now logs when a variable expanded in a unit file is not explicitly defined. Thus, in the systemd service when we expand the variable a warning is logged https://github.com/Irqbalance/irqbalance/blob/master/misc/irqbalance.service#L11. This behavior was introduced to systemd in versions 254+ https://github.com/systemd/systemd-stable/commit/f331434d13488425ccd8485327085d15f8f92aea

Squelch this warning by uncommenting IRQBALANCE_ARGS in irqbalance.env, instead setting it to the empty string.

Addresses https://github.com/Irqbalance/irqbalance/issues/321 