### PR TITLE
Version option should return 0 rather than 1

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -122,7 +122,7 @@ static void parse_command_line(int argc, char **argv)
 				break;
 			case 'V':
 				version();
-				exit(1);
+				exit(0);
 				break;
 			case 'c':
 				deepest_cache = strtoul(optarg, &endptr, 10);


### PR DESCRIPTION
Previously invoke irqbalance with --version options, the return value is 1 instead of 0:

$ irqbalance --version
irqbalance version 1.9.4
$ echo $?
1

It is unexpected because irqbalance have successfully returned the version string with no errors, so 0 should be returned instead of 1. This will confuse some automation tests.

This patch will make irqbalance return the correct value for version option.