### PR TITLE
Use EPERM instead of EIO when try setting irq affinity fails

### DIFF
--- a/activate.c
+++ b/activate.c
@@ -95,6 +95,8 @@ static void activate_mapping(struct irq_info *info, void *data __attribute__((un
 	info->moved = 0; /*migration is done*/
 	return;
 error:
+	/* Use EPERM as the explaination for EIO */
+	errsave = (errsave == EIO) ? EPERM : errsave;
 	log(TO_ALL, LOG_WARNING,
 		"Cannot change IRQ %i affinity: %s\n",
 		info->irq, strerror(errsave));


### PR DESCRIPTION
Kernel commit eb29369fa543e ("genirq/proc: Change the return value for set affinity permission error") changed the error number from EIO to EPERM when a specific irq failed to set affinity from userspace.

In addition, users have complained about EIO is misleading when setting affinity fails, however it just meaning "user cannot set affinity", so EPERM is better for that.

This patch will follow the kernel change, to unify the behaviour of irqbalance from the kernels which have not integrated the kernel commit mentioned above.