### PR TITLE
Add SUPPRESS_LOG env to control the log outputs

### DIFF
--- a/misc/irqbalance.env
+++ b/misc/irqbalance.env
@@ -42,3 +42,11 @@
 #    page.
 #
 IRQBALANCE_ARGS=""
+
+#
+# SUPPRESS_LOG
+#    Configuration for suppress the following runtime logs:
+#       "Cannot change IRQ x affinity: ..." and
+#       "IRQ x affinity is now unmanaged"
+#    Uncomment to enable the suppression.
+#SUPPRESS_LOG=yes


### PR DESCRIPTION
When an IRQ fail to set affinity, irqbalance will output logs as: "Cannot change IRQ x affinity: ..." and "IRQ x affinity is now unmanaged". This usually happens at the start of irqbalance service, when irqbalance trying to detect if a specific IRQ is migratable. And in most cases, hardware/IRQs stay unchanged thus the logs only output once and acceptable.

However there are cases where hardware constantly goes online/offline for maintenance or other user requested actions, expecially the hardware holds lots of IRQs, irqbalance will output these logs lots of time thus over flood the journals and annoying.

This patch will introduce a SUPPRESS_LOG env variable, to help users suppress these logs when don't need.