### PR TITLE
Advance the signal handler add

### DIFF
--- a/irqbalance.c
+++ b/irqbalance.c
@@ -664,6 +664,13 @@ int main(int argc, char** argv)
 		}
 	}
 
+	g_unix_signal_add(SIGINT, handler, NULL);
+	g_unix_signal_add(SIGTERM, handler, NULL);
+	g_unix_signal_add(SIGUSR1, handler, NULL);
+	g_unix_signal_add(SIGUSR2, handler, NULL);
+	g_unix_signal_add(SIGHUP, force_rescan, NULL);
+	sigprocmask(SIG_SETMASK, &old_sigset, NULL);
+
 	build_object_tree();
 	if (debug_mode)
 		dump_object_tree();
@@ -677,14 +684,6 @@ int main(int argc, char** argv)
 		log(TO_ALL, LOG_WARNING, "%s", msg);
 		goto out;
 	}
-
-
-	g_unix_signal_add(SIGINT, handler, NULL);
-	g_unix_signal_add(SIGTERM, handler, NULL);
-	g_unix_signal_add(SIGUSR1, handler, NULL);
-	g_unix_signal_add(SIGUSR2, handler, NULL);
-	g_unix_signal_add(SIGHUP, force_rescan, NULL);
-	sigprocmask(SIG_SETMASK, &old_sigset, NULL);
 
 #ifdef HAVE_LIBCAP_NG
 	// Drop capabilities


### PR DESCRIPTION
When there are too many devices in the /sys/bus/pci/devices directory, it will increase the service startup time. In my environment, the build_dev_irqs() function takes more than 30 seconds. During this time, the service will not be able to respond to some signals (such as the -15 signal sent by systemd).

