### PR TITLE
check_platform_device: Check the length of path

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -72,7 +72,8 @@ static int check_platform_device(char *name, struct irq_info *info)
 	memset(path, 0, 512);
 
 	strcat(path, "/sys/devices/platform/");
-	strcat(path, name);
+	snprintf(path + strlen(path), sizeof(path) - strlen(path) - 1,
+		"%s", name);
 	strcat(path, "/");
 	dirfd = opendir(path);
 


### PR DESCRIPTION
The default length of path is 512, but the strcat() is used without check if path is overflowed, otherwise a segfault is observed on some aarch64 machines. This patch will use snprintf instead of strcat for the buffer length checking.