### PR TITLE
Fix the wrong string existence checking condition

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -172,9 +172,9 @@ void init_irq_class_and_type(char *savedline, struct irq_info *info, int irq)
 		 * /proc/interrupts format defined, after of interrupt type
 		 * the reset string is mark the irq desc name.
 		 */
-		if (!g_str_has_prefix(irq_name, "Level") ||
-                                !g_str_has_prefix(irq_name, "Edge"))
-                        break;
+		if (g_str_has_prefix(irq_name, "Level") ||
+				g_str_has_prefix(irq_name, "Edge"))
+			break;
 #endif
 	}
 


### PR DESCRIPTION
Commit da75aae4effd ("conver strncmp to g_str_has_prefix") introduced an error which reversed the string existence checking condition.

Before that commit, the check condition is:
  (strncmp(name, "Level", len) == 0 || strncmp(name, "Edge", len) == 0)

After that commit, the check condition is equal to:
  (strncmp(name, "Level", len) != 0 || strncmp(name, "Edge", len) != 0)

This is unexpected and let's fixe this error.