### PR TITLE
Properly embed EnvironmentFile and unify meson and autoconf build env

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,10 @@
 
 AUTOMAKE_OPTIONS = no-dependencies
 ACLOCAL_AMFLAGS = -I m4
-EXTRA_DIST = COPYING autogen.sh misc/irqbalance.service misc/irqbalance.env
+EXTRA_DIST = COPYING autogen.sh
+
+systemdsystemunit_DATA = misc/irqbalance.service
+pkgconf_DATA = misc/irqbalance.env
 
 SUBDIRS = tests
 

--- a/configure.ac
+++ b/configure.ac
@@ -115,6 +115,24 @@ AS_IF(
   ]
 )
 
+AC_ARG_WITH([pkgconfdir],
+  [AS_HELP_STRING([--with-pkgconfdir=DIR],
+    [Systemd Environment configs sourced by irqbalanced])],
+    [pkgconfdir=$withval],
+    [pkgconfdir="$prefix/etc/default"])
+AC_SUBST([pkgconfdir])
+
+AC_ARG_WITH([usrconfdir],
+  [AS_HELP_STRING([--with-usrconfdir=DIR],
+    [Systemd Environment user configs sourced by irqbalanced])],
+    [usrconfdir=$withval],
+    [usrconfdir="${sysconfdir}/default"])
+AC_SUBST([usrconfdir])
+
+AC_CONFIG_FILES([misc/irqbalance.service])
+
+PKG_CHECK_VAR([systemdsystemunitdir], [systemd], [systemdsystemunitdir])
+
 AC_OUTPUT(Makefile tests/Makefile)
 
 AC_MSG_NOTICE()
@@ -123,3 +141,4 @@ AC_MSG_NOTICE([Target:                 $target])
 AC_MSG_NOTICE([Installation prefix:    $prefix])
 AC_MSG_NOTICE([Compiler:               $CC])
 AC_MSG_NOTICE([Compiler flags: $CFLAGS])
+AC_MSG_NOTICE([Systemdunitdir:         $systemdsystemunitdir])

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,13 @@ numa_dep = cc.find_library('numa', required: get_option('numa'))
 libnl_3_dep = dependency('libnl-3.0', required: get_option('thermal'))
 libnl_genl_3_dep = dependency('libnl-genl-3.0', required: get_option('thermal'))
 systemd_dep = dependency('libsystemd', required: get_option('systemd'))
+systemd_dir_dep = dependency('systemd', required: get_option('systemd'))
+
+systemdsystemunitdir = systemd_dir_dep.get_variable(
+  pkgconfig: 'systemdsystemunitdir',
+  default_value: get_option('prefix') / 'lib/systemd/system'
+)
+
 
 cdata = configuration_data()
 cdata.set('HAVE_GETOPT_LONG', cc.has_function('getopt_long'))
@@ -68,3 +75,33 @@ executable(
 )
 
 install_man('irqbalance.1')
+
+if systemd_dep.found()
+  pkgconfdir = get_option('pkgconfdir')
+  usrconfdir = get_option('usrconfdir')
+
+# Set defaults
+  if pkgconfdir == ''
+     pkgconfdir = get_option('prefix') / 'etc/default'
+  endif
+  if usrconfdir == ''
+     usrconfdir = get_option('sysconfdir') / 'default'
+  endif
+
+  idata = configuration_data()
+  idata.set('usrconfdir', usrconfdir)
+  idata.set('pkgconfdir', pkgconfdir)
+
+  configure_file(
+    input: 'misc/irqbalance.service.in',
+    output: 'irqbalance.service',
+    install_dir: systemdsystemunitdir,
+    configuration: idata
+  )
+  configure_file(
+    input: 'misc/irqbalance.env',
+    output: 'irqbalance.env',
+    install_dir: pkgconfdir,
+    configuration: idata
+  )
+endif

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,7 @@ if cdata.get('HAVE_IRQBALANCEUI')
     'ui/ui.c',
     dependencies: [glib_dep, ncurses_dep],
     install: true,
+    install_dir : get_option('sbindir'),
   )
 
   install_man('irqbalance-ui.1')
@@ -63,6 +64,7 @@ executable(
   irqbalance_sources,
   dependencies: [glib_dep, m_dep, capng_dep, libnl_3_dep, libnl_genl_3_dep, numa_dep, systemd_dep],
   install: true,
+  install_dir : get_option('sbindir'),
 )
 
 install_man('irqbalance.1')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,3 +17,11 @@ option('thermal', type : 'feature',
 option('ui', type : 'feature',
   description : 'Build the UI component',
 )
+
+option('usrconfdir', type: 'string',
+  description: 'Directory to systemd environment file, optionally added by user'
+)
+
+option('pkgconfdir', type: 'string',
+  description: 'Directory to systemd environment file, provided by irqbalance'
+)

--- a/misc/irqbalance.service.in
+++ b/misc/irqbalance.service.in
@@ -6,8 +6,8 @@ ConditionVirtualization=!container
 ConditionCPUs=>1
 
 [Service]
-EnvironmentFile=-/usr/lib/irqbalance/defaults.env
-EnvironmentFile=-/path/to/irqbalance.env
+EnvironmentFile=@pkgconfdir@/irqbalance.env
+EnvironmentFile=-@usrconfdir@/irqbalance
 ExecStart=/usr/sbin/irqbalance $IRQBALANCE_ARGS
 CapabilityBoundingSet=CAP_SETPCAP
 NoNewPrivileges=yes


### PR DESCRIPTION
Having two EnvironmentFile key words to get replace due to a recent irqbalance.service change, got silently wrong by an sed replacement of config paths...

These 2 patches unify and enhance the meson and autoconf build setup and make the 2 EnvironmentFile directories configurable.