### PR TITLE
Increase file descriptor limit via systemd service file

### DIFF
--- a/misc/irqbalance.service.in
+++ b/misc/irqbalance.service.in
@@ -16,6 +16,7 @@ ReadOnlyPaths=/
 ReadWritePaths=/proc/irq
 RestrictAddressFamilies=AF_UNIX AF_NETLINK
 RuntimeDirectory=irqbalance/
+LimitNOFILE=4096
 IPAddressDeny=any
 ProtectHome=true
 PrivateTmp=yes 


### PR DESCRIPTION
Default file limit value set by systemd can be found: systemctl show --property DefaultLimitNOFILESoft
DefaultLimitNOFILESoft=1024

This limit could easily be exceeded on larger systems resulting in:

Starting irqbalance Can't open class file: : Too many open files
startproc:  signal catched /usr/sbin/irqbalance: Segmentation fault

Adding the property to irqbalance.service.in sets a sane default and allows people to easily find the right place where to adjust the limit.