### PR TITLE
Fix overflow check platform device

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -55,7 +55,7 @@ struct irq_match {
 static int check_platform_device(char *name, struct irq_info *info)
 {
 	DIR *dirfd;
-	char path[512];
+	char path[PATH_MAX];
 	struct dirent *ent;
 	int rc = -ENOENT, i;
 	static struct pdev_irq_info {
@@ -69,12 +69,11 @@ static int check_platform_device(char *name, struct irq_info *info)
 		{NULL},
 	};
 
-	memset(path, 0, 512);
+	if (snprintf(path, PATH_MAX, "/sys/devices/platform/%s", name) == PATH_MAX) {
+		log(TO_ALL, LOG_ERROR, "Device path in /sys exceeds maximum length");
+		return -ENAMETOOLONG;
+	}
 
-	strcat(path, "/sys/devices/platform/");
-	snprintf(path + strlen(path), sizeof(path) - strlen(path) - 1,
-		"%s", name);
-	strcat(path, "/");
 	dirfd = opendir(path);
 
 	if (!dirfd) {

--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -69,8 +69,8 @@ static int check_platform_device(char *name, struct irq_info *info)
 		{NULL},
 	};
 
-	if (snprintf(path, PATH_MAX, "/sys/devices/platform/%s", name) == PATH_MAX) {
-		log(TO_ALL, LOG_ERROR, "Device path in /sys exceeds maximum length");
+	if (snprintf(path, PATH_MAX, "/sys/devices/platform/%s/", name) == PATH_MAX) {
+		log(TO_ALL, LOG_WARNING, "WARNING: Platform device path in /sys exceeds PATH_MAX, cannot examine");
 		return -ENAMETOOLONG;
 	}
 


### PR DESCRIPTION
There is an overly short buffer in procinterrupts.c that could be exceeded by a long but still valid device name (PATH_MAX is 4096, the buffer was only 512). In such case, the contents would be truncated to 511 byte, and the following appending of "/" would overwrite the terminating zero, causing a buffer overflow.

This is my attempt to fix this.