### PR TITLE
Fix a typo/thinko in fix to check_platform_device()

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -69,7 +69,7 @@ static int check_platform_device(char *name, struct irq_info *info)
 		{NULL},
 	};
 
-	if (snprintf(path, PATH_MAX, "/sys/devices/platform/%s/", name) == PATH_MAX) {
+	if (snprintf(path, PATH_MAX, "/sys/devices/platform/%s/", name) >= PATH_MAX) {
 		log(TO_ALL, LOG_WARNING, "WARNING: Platform device path in /sys exceeds PATH_MAX, cannot examine");
 		return -ENAMETOOLONG;
 	}


### PR DESCRIPTION
Apologies, I was hit by a temporary bout of stupidity and forgot that strnprintf() returns the number of bytes that would be written if the buffer was sufficient, not the real number of bytes written - so its result may be larger than PATH_MAX and must be compared using >=, not ==.