### PR TITLE
Fix irqbalance for Xen virtual event interrupts

### DIFF
--- a/procinterrupts.c
+++ b/procinterrupts.c
@@ -191,7 +191,7 @@ void init_irq_class_and_type(char *savedline, struct irq_info *info, int irq)
 #endif
 	info->irq = irq;
 
-	if (strstr(irq_fullname, "-event") != NULL && is_xen_dyn == 1) {
+	if (strstr(irq_name, "-event") != NULL && is_xen_dyn == 1) {
 		info->type = IRQ_TYPE_VIRT_EVENT;
 		info->class = IRQ_VIRT_EVENT;
 	} else {


### PR DESCRIPTION
Xen VIF interrupts were getting classified as other, instead of virt-event:
```
 312:    2453008          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0  xen-dyn-lateeoi     -event     vif13.0-q1-tx
Interrupt 312 node_num is -1 (other/0:7)
```

And then they were not being moved at all, and some interrupts were running on CPU0 (which is also busy with other legacy interrupts).

In the past they were classified as virt-event:
```
Interrupt 343 node_num is -1 (virt-event/0)
```

GDB shows that irq_fullname is 'vif1.0-q0-tx', and not '-event', so this condition no longer triggers:
```
   if (strstr(irq_fullname, "-event") != NULL && is_xen_dyn == 1) {
        info->type = IRQ_TYPE_VIRT_EVENT;
        info->class = IRQ_VIRT_EVENT;
```

Instead `irq_name` should be used, which points to the previous token, '-event'. After this patch the IRQ gets classified correctly (the number changed because I rebooted inbetween):
```
 Interrupt 302 node_num is -1 (virt-event/0:0)
```

The regression was introduced by a change to ARM-specific code that changed Xen code (accidentally?).
The commit was for lines of this form:
```
43:          1          0          0          0   ITS-MSI 16384 Edge      PCIe PME, aerdrv, pciehp
```
That should be unaffected by this change: it doesn't contain '-event' and doesn't contain 'xen-dyn', so the 'if' condition will stay false after this patch, and the 'else' side would run, which contains the ARM code.

This is a regression from irqbalance 1.0.9 according to git history.

Fixes: d17bcc9 ("Fix irqbalance cannot obtain the full name of irq")