### PR TITLE
meson: force systemd-service installation with a seperate option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -76,7 +76,7 @@ executable(
 
 install_man('irqbalance.1')
 
-if systemd_dep.found()
+if systemd_dep.found() or get_option('systemd-service')
   pkgconfdir = get_option('pkgconfdir')
   usrconfdir = get_option('usrconfdir')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,6 +10,10 @@ option('systemd', type : 'feature', value: 'enabled',
   description : 'Build with systemd support',
 )
 
+option('systemd-service', type : 'boolean',
+  description : 'Install systemd service (true if systemd option is enabled)',
+)
+
 option('thermal', type : 'feature',
   description : 'Build with thermal support',
 )


### PR DESCRIPTION
Allows the systemd service installation without systemd build-dependency (as we in Alpine allow systemd services to be included for downstreams, but don't have systemd in Alpine).