### PR TITLE
docs: document an edge case for `IRQBALANCE_BANNED_CPULIST`

### DIFF
--- a/irqbalance.1
+++ b/irqbalance.1
@@ -183,6 +183,9 @@ for the consider of compatibility.
 Provides a cpulist which irqbalance should ignore and never assign interrupts to.
 If not specified, irqbalance use mask of isolated and adaptive-ticks CPUs on the
 system as the default value.
+Notes: Providing an invalid value or an empty list (e.g., "-") 
+will result in an empty banned mask, effectively allowing all 
+CPUs on the system to participate in the IRQ balancing.
 
 .SH "SIGNALS"
 .TP


### PR DESCRIPTION
In a case when user wants to set the `IRQBALANCE_BANNED_CPULIST` variable as empty,
it cannot use the empty string `""` for that, since irqbalance apply a custom logic for not placing  IRQs on `isolated` or `nohz_full` cpus by default.

This PR adds a documentation for how to override the default behaviour and set an empty banned list where all CPUs are participating in the IRQ balancing.  

Signed-off-by: Talor Itzhak <titzhak@redhat.com>