### PR TITLE
Slot-aware placement follow-ups: tie-breaker, ENOSPC saturation marker, and BALANCE_NONE policy fix

### DIFF
--- a/activate.c
+++ b/activate.c
@@ -167,7 +167,7 @@ static const char *balance_level_str(int level)
  *   - BALANCE_CORE: No fallback possible (single CPU, fail immediately)
  *   - BALANCE_CACHE: Only search within same cache domain
  *   - BALANCE_PACKAGE: Only search within same package
- *   - BALANCE_NONE: Search within same NUMA node (widest scope)
+ *   - BALANCE_NONE: User opted out of balancing - decline fallback
  *
  * FIXES APPLIED:
  *   1. NUMA fallback now traverses topology tree to find actual CPUs
@@ -205,6 +205,22 @@ static int try_fallback_cpu(struct irq_info *info, cpumask_t applied_mask,
 		return -1;
 	}
 
+	/*
+	 * BALANCE_NONE means the user opted this IRQ out of balancing.
+	 * place_irq_in_node() only relocates such an IRQ when banned CPUs
+	 * forced it; we should not silently widen the scope further on
+	 * ENOSPC. Treat it like BALANCE_CORE: warn and decline.
+	 * This also avoids a NULL search_scope on non-NUMA systems where
+	 * no OBJ_TYPE_NODE ancestor exists in the topology.
+	 */
+	if (balance_level == BALANCE_NONE) {
+		log(TO_ALL, LOG_WARNING,
+			"IRQ %d: cannot fallback - balance level is 'none' "
+			"(user policy forbids relocation)\n",
+			info->irq);
+		return -1;
+	}
+
 	cpus_clear(tried_cpus);
 
 	/*
@@ -228,11 +244,6 @@ static int try_fallback_cpu(struct irq_info *info, cpumask_t applied_mask,
 		case BALANCE_PACKAGE:
 			search_scope = original->parent;
 			while (search_scope && search_scope->obj_type != OBJ_TYPE_PACKAGE)
-				search_scope = search_scope->parent;
-			break;
-		case BALANCE_NONE:
-			search_scope = original->parent;
-			while (search_scope && search_scope->obj_type != OBJ_TYPE_NODE)
 				search_scope = search_scope->parent;
 			break;
 		default:

--- a/activate.c
+++ b/activate.c
@@ -359,6 +359,23 @@ static int try_fallback_cpu(struct irq_info *info, cpumask_t applied_mask,
 		 *
 		 */
 		migrate_irq_obj(original, fallback, info);
+		/*
+		 * migrate_irq_obj() unconditionally increments the source
+		 * object's slots_left (0 -> 1), which would make the original
+		 * CPU look eligible again. The kernel returned ENOSPC, so its
+		 * vector table is still full; re-clamp to SATURATED so we
+		 * don't immediately retry the same dead-end placement.
+		 *
+		 * Only re-clamp when the source is an actual CPU. For
+		 * domain-assigned IRQs (cache/package/NUMA), the original
+		 * is a domain object whose slots_left aggregates its CPUs
+		 * and was never marked SLOTS_SATURATED by the ENOSPC handler
+		 * (see activate_mapping(): the obj_type==CPU branch).
+		 * Force-saturating the whole domain would penalize every CPU
+		 * inside it on the next placement cycle.
+		 */
+		if (original->obj_type == OBJ_TYPE_CPU)
+			original->slots_left = SLOTS_SATURATED;
 		info->moved = 0;
 		log(TO_ALL, LOG_DEBUG,
 			"IRQ %d: successfully placed on fallback CPU %d "

--- a/placement.c
+++ b/placement.c
@@ -125,10 +125,16 @@ static void find_best_object(struct topo_obj *d, void *data)
 		best->best_cost = newload;
 	} else if (adjusted_cost == best_adjusted_cost) {
 		/*
-		 * Tie-breaker: prefer CPU with more slots_left (more headroom).
-		 * This avoids O(n) g_list_length() calls and uses already-available data.
+		 * Tie-breaker: first prefer the CPU with more slots_left
+		 * (more headroom). During normal operation slots_left is
+		 * INT_MAX for all CPUs (see clear_slots()), so fall back to
+		 * the original interrupt-count comparison to keep IRQs
+		 * spread across CPUs that currently hold fewer interrupts.
 		 */
-		if (!best->best || d->slots_left > best->best->slots_left) {
+		if (!best->best ||
+		    d->slots_left > best->best->slots_left ||
+		    (d->slots_left == best->best->slots_left &&
+		     g_list_length(d->interrupts) < g_list_length(best->best->interrupts))) {
 			best->best = d;
 			best->best_cost = newload;
 		}


### PR DESCRIPTION
A couple of small follow-up fixes identified during post-merge review of the slot-aware placement and ENOSPC fallback work (merged via PR #360). All are surgical corrections — none changes the feature's contract; each either restores behavior that was pre-existing upstream, tightens the saturation marker's semantics, or aligns `try_fallback_cpu()` with the documented meaning of `BALANCE_NONE` everywhere else in the codebase. Each commit is independently revertible.

## Scope and impact

- No change to the ENOSPC happy-path for `BALANCE_PACKAGE` / `BALANCE_CACHE` IRQs — workloads that exercised the original slot-aware patch remain functionally identical.
- `9f5a4bc` only changes tie-break ordering when `adjusted_cost` is equal.
- `52a5e95` only suppresses a redundant retry on an already-known-full CPU.
- `a242d32` is a no-op for any user who has not set `balance_level=none` via policy script; for those who have, it preserves their explicit policy choice rather than silently overriding it.

## `9f5a4bc` — placement: restore interrupt-count tie-breaker in find_best_object()

The slot-aware patch replaced the historical `g_list_length(d->interrupts) < g_list_length(best->interrupts)` tie-breaker with a comparison on `slots_left`. However, `slots_left` is initialized to `INT_MAX` by `clear_slots()` at daemon startup (and again after CPU hotplug), and `migrate_irq_obj()` guards both its decrement and increment with `slots_left != INT_MAX`. Once a CPU is at `INT_MAX`, no normal migration takes it out of that state; only the ENOSPC handler's explicit assignment to `SLOTS_SATURATED` (0) does. As a result, on any system that has not experienced an ENOSPC event, every CPU keeps `slots_left == INT_MAX` for the daemon's entire lifetime and the comparison `d->slots_left > best->slots_left` is always false.

The net effect is that ties on `adjusted_cost` are now resolved by iteration order rather than by current interrupt population. Ties are the common case at daemon startup and on idle/lightly-loaded systems where many IRQs have `load == 0`; the bias causes such IRQs to pile onto the lowest-numbered CPU in each domain.

The fix restores the original `g_list_length()` comparison as a secondary tie-breaker. The `slots_left` comparison is kept as the primary tie-breaker so ENOSPC-recovery behavior is preserved on systems where `slots_left` does diverge between CPUs.

## `52a5e95` — activate: keep ENOSPC source CPU saturated after fallback migration

When `try_fallback_cpu()` successfully relocates an IRQ away from a CPU that returned `ENOSPC`, it calls `migrate_irq_obj(original, fallback, info)` to update the topology bookkeeping. That helper unconditionally increments `from->slots_left`, taking the original CPU from `SLOTS_SATURATED` (0) back to 1.

The kernel returned `ENOSPC` because the original CPU's vector table is full; irqbalance only moved its internal tracking — the kernel write that would actually free a vector never succeeded. Letting `slots_left` rebound to 1 makes the saturated CPU look eligible for the next IRQ in the same cycle (only suppressed by the `slots_penalty` in `find_best_object()`), which can lead to a redundant ENOSPC retry on a CPU we already know is full.

The fix re-clamps `original->slots_left` to `SLOTS_SATURATED` immediately after the migration, but **only when the source is an actual CPU**. For domain-assigned IRQs the original is a cache/package/NUMA object whose `slots_left` aggregates its children and was never marked `SLOTS_SATURATED` by the ENOSPC handler in the first place; clamping the whole domain would penalize every CPU inside it on the next placement cycle. A cleaner alternative — teaching `migrate_irq_obj()` itself to skip the increment when the source is `SLOTS_SATURATED` — was considered but rejected because the ENOSPC-fallback path is the only caller where the source has not genuinely freed a vector.

## `a242d32` — activate: do not relocate BALANCE_NONE IRQs on ENOSPC

`BALANCE_NONE` means the user has opted this IRQ out of automatic balancing. The placement code only ever moves such an IRQ when banned CPUs force a relocation (see `place_irq_in_node()`'s `cpus_empty(banned_cpus)` guard); every other code path (`move_candidate_irqs()`, `force_rebalance_irq()`, `find_best_object_for_irq()`) treats `BALANCE_NONE` as "leave this IRQ alone".

The ENOSPC fallback path was treating `BALANCE_NONE` as a request to search across the entire NUMA node, which:

1. Violates the documented semantics of `BALANCE_NONE` everywhere else in the codebase.
2. Silently widens scope beyond what the user asked for: the IRQ hits ENOSPC on its current CPU, then irqbalance moves it to an arbitrary other CPU within the NUMA node without any indication to the operator.
3. Is unreachable on non-NUMA systems: the topology has no `OBJ_TYPE_NODE` ancestor for a CPU there, so the parent walk returns NULL and `try_fallback_cpu()` bails out at the *"no valid search scope"* warning, masking what is essentially dead code.

Treat `BALANCE_NONE` the same as `BALANCE_CORE`: log a warning and decline the fallback. Users who want ENOSPC recovery should configure `balance_level=package` (or `cache`) explicitly.